### PR TITLE
[feat] support TypeScript configuration file

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,5 +17,7 @@ module.exports = {
     'no-extra-semi': 'off',
     eqeqeq: ['error', 'always'],
     'n/no-process-exit': 'off',
+    'n/no-unpublished-import': 'off',
+    'n/no-unpublished-require': 'off',
   },
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "fast-glob": "^3.2.12",
     "fast-json-stable-stringify": "^2.1.0",
     "kleur": "^4.1.5",
+    "source-map-support": "^0.5.21",
     "strip-ansi": "^7.0.1",
     "yaml": "^2.2.1"
   },
@@ -56,6 +57,7 @@
     "@types/cross-spawn": "^6.0.2",
     "@types/jest": "^29.5.0",
     "@types/node": "^18.15.11",
+    "@types/source-map-support": "^0.5.6",
     "@typescript-eslint/eslint-plugin": "^5.58.0",
     "@typescript-eslint/parser": "^5.58.0",
     "esbuild": "^0.17.15",
@@ -69,7 +71,6 @@
     "node-gyp": "^9.3.1",
     "prettier": "^2.8.7",
     "prettier-plugin-organize-imports": "^3.2.2",
-    "typescript": "^5.0.3",
-    "unconfig": "^0.3.7"
+    "typescript": "^5.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "node-gyp": "^9.3.1",
     "prettier": "^2.8.7",
     "prettier-plugin-organize-imports": "^3.2.2",
-    "typescript": "^5.0.3"
+    "typescript": "^5.0.3",
+    "unconfig": "^0.3.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ dependencies:
   kleur:
     specifier: ^4.1.5
     version: 4.1.5
+  source-map-support:
+    specifier: ^0.5.21
+    version: 0.5.21
   strip-ansi:
     specifier: ^7.0.1
     version: 7.0.1
@@ -33,6 +36,9 @@ devDependencies:
   '@types/node':
     specifier: ^18.15.11
     version: 18.15.11
+  '@types/source-map-support':
+    specifier: ^0.5.6
+    version: 0.5.6
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.58.0
     version: 5.58.0(@typescript-eslint/parser@5.58.0)(eslint@8.38.0)(typescript@5.0.3)
@@ -75,9 +81,6 @@ devDependencies:
   typescript:
     specifier: ^5.0.3
     version: 5.0.3
-  unconfig:
-    specifier: ^0.3.7
-    version: 0.3.7
 
 packages:
 
@@ -87,10 +90,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
-    dev: true
-
-  /@antfu/utils@0.5.2:
-    resolution: {integrity: sha512-CQkeV+oJxUazwjlHD0/3ZD08QWKuGQkhnrKo3e6ly5pd48VUpXbb77q0xMU4+vc2CkJnDS02Eq/M9ugyX20XZA==}
     dev: true
 
   /@babel/code-frame@7.21.4:
@@ -1156,6 +1155,12 @@ packages:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
     dev: true
 
+  /@types/source-map-support@0.5.6:
+    resolution: {integrity: sha512-b2nJ9YyXmkhGaa2b8VLM0kJ04xxwNyijcq12/kDoomCt43qbHBeK2SLNJ9iJmETaAj+bKUT05PQUu3Q66GvLhQ==}
+    dependencies:
+      source-map: 0.6.1
+    dev: true
+
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
@@ -1666,7 +1671,6 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: true
 
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
@@ -1990,10 +1994,6 @@ packages:
     dependencies:
       is-descriptor: 1.0.2
       isobject: 3.0.1
-    dev: true
-
-  /defu@6.1.2:
-    resolution: {integrity: sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==}
     dev: true
 
   /delegates@1.0.0:
@@ -3526,11 +3526,6 @@ packages:
       - ts-node
     dev: true
 
-  /jiti@1.18.2:
-    resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
-    hasBin: true
-    dev: true
-
   /js-sdsl@4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
     dev: true
@@ -4633,6 +4628,13 @@ packages:
       source-map: 0.6.1
     dev: true
 
+  /source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: false
+
   /source-map-url@0.4.1:
     resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==}
     deprecated: See https://github.com/lydell/source-map-url#deprecated
@@ -4646,7 +4648,6 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /split-string@3.1.0:
     resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
@@ -4901,14 +4902,6 @@ packages:
     resolution: {integrity: sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==}
     engines: {node: '>=12.20'}
     hasBin: true
-    dev: true
-
-  /unconfig@0.3.7:
-    resolution: {integrity: sha512-1589b7oGa8ILBYpta7TndM5mLHLzHUqBfhszeZxuUBrjO/RoQ52VGVWsS3w0C0GLNxO9RPmqkf6BmIvBApaRdA==}
-    dependencies:
-      '@antfu/utils': 0.5.2
-      defu: 6.1.2
-      jiti: 1.18.2
     dev: true
 
   /union-value@1.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ devDependencies:
   typescript:
     specifier: ^5.0.3
     version: 5.0.3
+  unconfig:
+    specifier: ^0.3.7
+    version: 0.3.7
 
 packages:
 
@@ -84,6 +87,10 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
+    dev: true
+
+  /@antfu/utils@0.5.2:
+    resolution: {integrity: sha512-CQkeV+oJxUazwjlHD0/3ZD08QWKuGQkhnrKo3e6ly5pd48VUpXbb77q0xMU4+vc2CkJnDS02Eq/M9ugyX20XZA==}
     dev: true
 
   /@babel/code-frame@7.21.4:
@@ -1985,6 +1992,10 @@ packages:
       isobject: 3.0.1
     dev: true
 
+  /defu@6.1.2:
+    resolution: {integrity: sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==}
+    dev: true
+
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
     dev: true
@@ -3515,6 +3526,11 @@ packages:
       - ts-node
     dev: true
 
+  /jiti@1.18.2:
+    resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
+    hasBin: true
+    dev: true
+
   /js-sdsl@4.4.0:
     resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
     dev: true
@@ -4885,6 +4901,14 @@ packages:
     resolution: {integrity: sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==}
     engines: {node: '>=12.20'}
     hasBin: true
+    dev: true
+
+  /unconfig@0.3.7:
+    resolution: {integrity: sha512-1589b7oGa8ILBYpta7TndM5mLHLzHUqBfhszeZxuUBrjO/RoQ52VGVWsS3w0C0GLNxO9RPmqkf6BmIvBApaRdA==}
+    dependencies:
+      '@antfu/utils': 0.5.2
+      defu: 6.1.2
+      jiti: 1.18.2
     dev: true
 
   /union-value@1.0.1:

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 import slugify from '@sindresorhus/slugify'
 import glob from 'fast-glob'
-import { readFileSync, unlinkSync, writeFileSync } from 'fs'
+import { readFileSync } from 'fs'
 import kleur from 'kleur'
 import path from 'path'
 import { log } from './log.js'
@@ -63,20 +63,15 @@ async function loadConfigFromFile(file) {
       outfile: 'out.js',
       target: 'esnext',
       platform: 'node',
+      sourcemap: 'inline',
       format: 'esm',
       write: false,
     })
     const { text } = result.outputFiles[0]
 
-    const fileBase = `${file}-${Date.now()}`
-    const fileNameTmp = `${fileBase}.mjs`
-    writeFileSync(fileNameTmp, text)
+    const dataUrl = `data:text/javascript;base64,${Buffer.from(text).toString('base64')}`
 
-    try {
-      return (await import(fileNameTmp)).default
-    } finally {
-      unlinkSync(fileNameTmp)
-    }
+    return (await import(dataUrl)).default
   } else {
     return (await import(file)).default
   }


### PR DESCRIPTION
Handle configuration files with `ts`, `cts` and `mts` file extensions.

Use esbuild to transpile TS file to JS, and create JS temporary file in the root directory. Temporary file is deleted after config is loaded.

Closes #3.