### PR TITLE
[fix] make path in stack trace of TS config file clickable

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,7 +3,6 @@ module.exports = {
   env: {
     es2021: true,
     node: true,
-    'jest/globals': true,
   },
   extends: ['eslint:recommended', 'plugin:n/recommended', 'plugin:@typescript-eslint/recommended'],
   parser: '@typescript-eslint/parser',
@@ -20,6 +19,9 @@ module.exports = {
     },
     {
       files: ['test/**'],
+      env: {
+        'jest/globals': true,
+      },
       plugins: ['jest'],
       extends: ['plugin:jest/recommended'],
       rules: {},

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,7 @@
 import slugify from '@sindresorhus/slugify'
 import glob from 'fast-glob'
-import { mkdirSync, readFileSync, writeFileSync } from 'fs'
-import os from 'os'
-import path, { dirname, join } from 'path'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import path, { join } from 'path'
 import 'source-map-support/register.js'
 import { logger } from './logger/logger.js'
 import { workspaceRoot } from './workspaceRoot.js'
@@ -65,12 +64,14 @@ async function loadConfig(file) {
     return (await import(file)).default
   }
 
-  const tmpDir = join(os.tmpdir(), '.lazyconfig', dirname(file))
-  mkdirSync(tmpDir, { recursive: true })
+  const configDir = join(workspaceRoot, '.lazy')
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir)
+  }
 
-  const inFile = join(tmpDir, 'config.source.mjs')
+  const inFile = join(configDir, 'config.source.mjs')
   writeFileSync(inFile, `import config from '${file}'; export default config`)
-  const outFile = join(tmpDir, 'config.cache.mjs')
+  const outFile = join(configDir, 'config.cache.mjs')
 
   const esbuild = await import('esbuild')
   await esbuild.build({


### PR DESCRIPTION
Save bundled config file to `.lazy` directory that will be created in the workspace root.

![Screen Shot 2023-04-14 at 21 02 10](https://user-images.githubusercontent.com/47859603/232133624-094a312e-c436-49e6-99a8-8ce32e67543f.png)

Closes #30.