### PR TITLE
[fix] TaskGraph execution

### DIFF
--- a/src/TaskGraph.js
+++ b/src/TaskGraph.js
@@ -201,7 +201,7 @@ export class TaskGraph {
       resolve = res
     })
 
-    const tick = async () => {
+    const tick = () => {
       const runningTasks = this.allRunningTasks()
       const readyTasks = this.allReadyTasks()
       const failedTasks = this.allFailedTasks()
@@ -238,7 +238,8 @@ export class TaskGraph {
       for (let i = 0; i < numTasksToStart; i++) {
         const taskKey = readyTasks[i]
         this.allTasks[taskKey].status = 'running'
-        await runTask(readyTasks[i])
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        runTask(readyTasks[i])
       }
 
       return true
@@ -253,8 +254,10 @@ export class TaskGraph {
           ? 'success:eager'
           : 'success:lazy'
         : 'failure'
-      await tick()
+      tick()
     }
+
+    tick()
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return await promise


### PR DESCRIPTION
The no-dangling-promises mitigation added a couple of issues in the TaskGraph:

- We accidentally removed the initial `tick()`, which meant the tasks never executed and the process sat idle waiting for a promise that would never be resolved.
- We added `await` in the scheduling for loop in the `tick` function, which meant that no parallelization was happening.

cc @mrkldshv this was my totally my fault for not reviewing the lint PR thoroughly, and having almost no tests 😅 I promise to fix both of those things asap