### PR TITLE
Fix getInputFiles

### DIFF
--- a/src/manifest/getInputFiles.js
+++ b/src/manifest/getInputFiles.js
@@ -61,13 +61,15 @@ export function getInputFiles(tasks, task, extraFiles) {
   const localFiles = globCacheConfig({
     task,
     workspaceRoot: tasks.config.workspaceRoot,
-    includes: replaceRootDirPragmas(
+    includes: makeGlobsAbsolute(
       uniq([...baseCacheConfig.includes, ...cacheConfig.inputs.include]),
       tasks.config.workspaceRoot,
+      task.taskDir,
     ),
-    excludes: replaceRootDirPragmas(
+    excludes: makeGlobsAbsolute(
       uniq([...baseCacheConfig.excludes, ...cacheConfig.inputs.exclude]),
       tasks.config.workspaceRoot,
+      task.taskDir,
     ),
   })
 
@@ -77,13 +79,19 @@ export function getInputFiles(tasks, task, extraFiles) {
 /**
  * @param {string[]} arr
  * @param {string} workspaceRoot
+ * @param {string} taskDir
  * @returns
  */
-const replaceRootDirPragmas = (arr, workspaceRoot) =>
-  arr.map((str) =>
-    str.startsWith('<rootDir>/') ? path.join(workspaceRoot, str.replace('<rootDir>/', '')) : str,
-  )
-
+const makeGlobsAbsolute = (arr, workspaceRoot, taskDir) =>
+  arr.map((str) => {
+    if (str.startsWith('<rootDir>/')) {
+      return path.join(workspaceRoot, str.replace('<rootDir>/', ''))
+    } else if (str.startsWith('/')) {
+      return str
+    } else {
+      return path.join(taskDir, str)
+    }
+  })
 /**
  *
  * @param {string} dir

--- a/test/integration/globbing.test.ts
+++ b/test/integration/globbing.test.ts
@@ -41,7 +41,7 @@ test('dependent tasks run', async () => {
 
         build::<rootDir> Finding files matching scripts/**/* took 1.00s
         build::<rootDir> Finding files matching scripts/build.js took 1.00s
-        build::<rootDir> Hashed 2/2 files in 1.00s
+        build::<rootDir> Hashed 1/1 files in 1.00s
         build::<rootDir> cache miss, no previous manifest found
         build::<rootDir> RUN node scripts/build.js > .out.txt in 
         build::<rootDir> input manifest saved: .lazy/manifests/build
@@ -56,6 +56,7 @@ test('dependent tasks run', async () => {
       `)
 
       expect(t.read('.lazy/manifests/build').includes('tsconfig.tsbuildinfo')).toBeFalsy()
+      expect(t.read('.lazy/manifests/build').includes('build.js')).toBeTruthy()
     },
   )
 })


### PR DESCRIPTION
fast-glob seems to get confused about ignoring precedence when some paths are absolute and others are relative. This make sure all paths are absolute so it works consistently.