### PR TITLE
Remove the directory after the tests ran.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "rimraf .test && jest",
     "update-snapshots": "jest -u",
     "clean": "rm -rf node_modules && pnpm install",
     "format": "prettier --write .",

--- a/test/integration/runIntegrationTests.ts
+++ b/test/integration/runIntegrationTests.ts
@@ -194,7 +194,6 @@ export async function runIntegrationTest(
 
   const t = new TestHarness({ dir, packageManager: config.packageManager, spawn: true })
   await fn(t)
-  naiveRimraf(dir)
 }
 
 export function makePackageJson(opts: Partial<PackageJson>) {

--- a/test/integration/runIntegrationTests.ts
+++ b/test/integration/runIntegrationTests.ts
@@ -194,6 +194,7 @@ export async function runIntegrationTest(
 
   const t = new TestHarness({ dir, packageManager: config.packageManager, spawn: true })
   await fn(t)
+  naiveRimraf(dir)
 }
 
 export function makePackageJson(opts: Partial<PackageJson>) {


### PR DESCRIPTION
Currently we were creating new folders in `.test` for reach test run and never removing them.  This cleans up after we are done running the test.