### PR TITLE
Rename `runType` to `execution`

### DIFF
--- a/src/TaskGraph.js
+++ b/src/TaskGraph.js
@@ -86,7 +86,7 @@ export class TaskGraph {
         )
       }
 
-      if (taskConfig.runType !== 'independent') {
+      if (taskConfig.execution !== 'independent') {
         for (const packageName of packageDetails?.localDeps ?? []) {
           const pkg = this.config.repoDetails.packagesByName[packageName]
           if (pkg.scripts?.[requestedTask.taskName]) {
@@ -112,7 +112,7 @@ export class TaskGraph {
      */
     const enqueueTask = (dir, requestedTask, dependencies) => {
       const rootTaskConfig = this.config.getTaskConfig(dir, requestedTask.taskName)
-      if (rootTaskConfig.runType === 'top-level') {
+      if (rootTaskConfig.execution === 'top-level') {
         dependencies?.push(
           this.config.getTaskKey(this.config.workspaceRoot, requestedTask.taskName),
         )

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -41,8 +41,8 @@ export class TaskConfig {
     return path.join(dir, slugify(this.name))
   }
 
-  get runType() {
-    return this._config.runType ?? 'dependent'
+  get execution() {
+    return this._config.execution ?? 'dependent'
   }
 
   get baseCommand() {

--- a/src/config/validateConfig.js
+++ b/src/config/validateConfig.js
@@ -43,7 +43,7 @@ const baseTaskSchema = z
 /** @type {z.ZodType<import('../types.js').TopLevelTask>} */
 export const topLevelTaskSchema = baseTaskSchema
   .extend({
-    runType: z.literal('top-level'),
+    execution: z.literal('top-level'),
     baseCommand: z.string(),
   })
   .strict()
@@ -51,7 +51,7 @@ export const topLevelTaskSchema = baseTaskSchema
 /** @type {z.ZodType<import('../types.js').PackageLevelTask>} */
 export const packageLevelTaskSchema = baseTaskSchema
   .extend({
-    runType: z.union([z.literal('dependent'), z.literal('independent')]).optional(),
+    execution: z.union([z.literal('dependent'), z.literal('independent')]).optional(),
     baseCommand: z.string().optional(),
   })
   .strict()

--- a/src/manifest/computeManifest.js
+++ b/src/manifest/computeManifest.js
@@ -63,7 +63,7 @@ export async function computeManifest({ tasks, task }) {
   for (const [otherTaskName, depConfig] of Object.entries(task.taskConfig.runsAfter ?? {})) {
     if (!depConfig.inheritsInput && depConfig.usesOutput === false) continue
     const isTopLevel =
-      tasks.config.getTaskConfig(task.taskDir, otherTaskName).runType === 'top-level'
+      tasks.config.getTaskConfig(task.taskDir, otherTaskName).execution === 'top-level'
 
     const key = tasks.config.getTaskKey(
       isTopLevel ? tasks.config.workspaceRoot : task.taskDir,
@@ -86,7 +86,7 @@ export async function computeManifest({ tasks, task }) {
   }
 
   if (
-    task.taskConfig.runType !== 'independent' &&
+    task.taskConfig.execution !== 'independent' &&
     (task.taskConfig.cache?.inheritsInputFromDependencies ?? true)
   ) {
     // TODO: test that localDeps is always sorted

--- a/src/runTask.js
+++ b/src/runTask.js
@@ -99,9 +99,11 @@ async function runTask(task, tasks) {
   /** @type {string} */
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   let command =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    taskConfig.runType === 'top-level' ? taskConfig.baseCommand : packageJson.scripts[task.taskName]
-  if (taskConfig.runType !== 'top-level' && command.startsWith('lazy inherit')) {
+    taskConfig.execution === 'top-level'
+      ? taskConfig.baseCommand
+      : // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        packageJson.scripts[task.taskName]
+  if (taskConfig.execution !== 'top-level' && command.startsWith('lazy inherit')) {
     if (!taskConfig.baseCommand) {
       // TODO: evaluate this stuff ahead-of-time
       logger.fail(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -126,7 +126,7 @@ export interface TopLevelTask extends BaseTask {
    *   You must specify a command to run.
    *   You may also want to add a `package.json` script with the same name that calls `lazy`.
    */
-  runType: 'top-level'
+  execution: 'top-level'
   /**
    * The command to run for this task
    */
@@ -155,7 +155,7 @@ export interface PackageLevelTask extends BaseTask {
    *   You may also want to add a `package.json` script with the same name that calls `lazy`.
    *
    */
-  runType?: 'dependent' | 'independent'
+  execution?: 'dependent' | 'independent'
   /**
    * The command to run for this task if the task uses `lazy inherit`
    */

--- a/test/integration/globbing.test.ts
+++ b/test/integration/globbing.test.ts
@@ -16,7 +16,7 @@ test('excludes take precedence', async () => {
               cache: {
                 inputs: ['scripts/build.js'],
               },
-              runType: 'top-level',
+              execution: 'top-level',
               baseCommand: 'node scripts/build.js > .out.txt',
             },
           },

--- a/test/integration/independent.test.ts
+++ b/test/integration/independent.test.ts
@@ -9,7 +9,7 @@ const makeDir = ({ buildCommand = 'echo $RANDOM > out.txt' } = {}): Dir => ({
             exclude: ['out.txt'],
           },
         },
-        runType: 'independent',
+        execution: 'independent',
       },
     },
   }),

--- a/test/integration/top-level.test.ts
+++ b/test/integration/top-level.test.ts
@@ -4,7 +4,7 @@ const makeDir = (): Dir => ({
   'lazy.config.js': makeConfigFile({
     tasks: {
       build: {
-        runType: 'top-level',
+        execution: 'top-level',
         cache: {
           inputs: {
             exclude: ['out.txt'],


### PR DESCRIPTION
Rename `runType` to `execution` globally.