### PR TITLE
Interpolate <rootDir> in commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint -f compact '**/*.{js,ts}'",
     "prepare": "husky install"
   },
-  "packageManager": "pnpm@latest",
+  "packageManager": "pnpm@8.3.1",
   "lint-staged": {
     "*.{js,ts}": [
       "eslint --fix"

--- a/src/TaskGraph.js
+++ b/src/TaskGraph.js
@@ -58,7 +58,7 @@ export class TaskGraph {
      * @returns
      */
     const visit = (path, { requestedTask, workspace }) => {
-      const taskConfig = this.config.getTaskConfig(workspace.dir, requestedTask.taskName)
+      const taskConfig = this.config.getTaskConfig(workspace, requestedTask.taskName)
       const key = this.config.getTaskKey(workspace.dir, requestedTask.taskName)
       if (this.allTasks[key]) {
         if (path.includes(key)) {
@@ -172,9 +172,7 @@ export class TaskGraph {
    * @param {string} taskName
    */
   isTopLevelTask(taskName) {
-    return (
-      this.config.getTaskConfig(this.config.project.root.dir, taskName).execution === 'top-level'
-    )
+    return this.config.getTaskConfig(this.config.project.root, taskName).execution === 'top-level'
   }
 
   /**

--- a/src/commands/inherit.js
+++ b/src/commands/inherit.js
@@ -1,4 +1,6 @@
 import { spawnSync } from 'child_process'
+import { relative } from 'path'
+import pc from 'picocolors'
 import { Config } from '../config/config.js'
 import { logger } from '../logger/logger.js'
 
@@ -11,19 +13,28 @@ export async function inherit() {
     process.exit(1)
   }
   const config = await Config.fromCwd(process.cwd())
-  const task = config.getTaskConfig(process.cwd(), scriptName)
+  const workspace = config.project.getWorkspaceByDir(process.cwd())
+  const task = config.getTaskConfig(workspace, scriptName)
   if (!task.baseCommand) {
     logger.fail(
       `No baseCommand found for task '${scriptName}'. Using 'lazy inherit' requires you to add a baseCommand for the relevant task in your lazy.config file!`,
     )
     process.exit(1)
   }
-  const result = spawnSync(task.baseCommand, process.argv.slice(3), {
+
+  const command = task.command
+  logger.log(
+    pc.bold('RUN ') +
+      pc.green(pc.bold(command)) +
+      pc.gray(' in ' + relative(process.cwd(), task.workspace.dir) ?? './'),
+  )
+
+  const result = spawnSync(command, process.argv.slice(3), {
     stdio: 'inherit',
     shell: true,
   })
   if (result.status === null) {
-    logger.fail(`Failed to run '${task.baseCommand}'`, { error: result.error })
+    logger.fail(`Failed to run '${command}'`, { error: result.error })
     process.exit(1)
   }
   process.exit(result.status)

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -33,7 +33,6 @@ export class TaskConfig {
   /** @private  */
   _config
   /**
-   * @param {Project} project
    * @param {import('../project/project-types.js').Workspace} workspace
    * @param {string} name
    * @param {Config} config

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -33,52 +33,57 @@ export class TaskConfig {
   /** @private  */
   _config
   /**
-   * @param {string} dir
+   * @param {Project} project
+   * @param {import('../project/project-types.js').Workspace} workspace
    * @param {string} name
-   * @param {import("./config-types.js").LazyTask} config
+   * @param {Config} config
    */
-  constructor(dir, name, config) {
-    this.dir = dir
+  constructor(workspace, name, config) {
+    this.workspace = workspace
     this.name = name
     this._config = config
   }
 
   getManifestPath() {
-    const dir = path.join(this.dir, '.lazy', 'manifests')
+    const dir = path.join(this.workspace.dir, '.lazy', 'manifests')
     return path.join(dir, slugify(this.name))
   }
 
   getNextManifestPath() {
-    const dir = path.join(this.dir, '.lazy', 'manifests')
+    const dir = path.join(this.workspace.dir, '.lazy', 'manifests')
     return path.join(dir, slugify(this.name) + '.next')
   }
 
   getDiffPath() {
-    const dir = path.join(this.dir, '.lazy', 'diffs')
+    const dir = path.join(this.workspace.dir, '.lazy', 'diffs')
     return path.join(dir, slugify(this.name))
   }
 
+  get taskConfig() {
+    return this._config.rootConfig.config.tasks?.[this.name] ?? {}
+  }
+
   get execution() {
-    return this._config.execution ?? 'dependent'
+    return this.taskConfig.execution ?? 'dependent'
   }
 
   get baseCommand() {
-    return this._config.baseCommand
+    return this.taskConfig.baseCommand
   }
 
   /** @type {[string, RunsAfterConfig][]} */
   get runsAfterEntries() {
-    return Object.entries(this._config.runsAfter ?? {}).map(([name, config]) => {
+    return Object.entries(this.taskConfig.runsAfter ?? {}).map(([name, config]) => {
       return [name, new RunsAfterConfig(config)]
     })
   }
 
   get parallel() {
-    return this._config.parallel ?? true
+    return this.taskConfig.parallel ?? true
   }
 
   get cache() {
-    const cache = this._config.cache
+    const cache = this.taskConfig.cache
     if (cache === 'none') {
       return cache
     } else {
@@ -90,6 +95,33 @@ export class TaskConfig {
         usesOutputFromDependencies: cache?.usesOutputFromDependencies ?? true,
       }
     }
+  }
+
+  get command() {
+    const baseCommand = this.baseCommand
+    const script = this.workspace.scripts[this.name]
+    let command = this.execution === 'top-level' ? baseCommand : script
+
+    if (!command) {
+      logger.fail(`No command found for script ${this.name} in ${this.workspace.dir}/package.json`)
+      process.exit(1)
+    }
+
+    if (this.execution !== 'top-level' && command.startsWith('lazy inherit')) {
+      if (!baseCommand) {
+        // TODO: evaluate this stuff ahead-of-time
+        logger.fail(
+          `Encountered 'lazy inherit' for scripts#${this.name} in ${this.workspace.dir}/package.json, but there is baseCommand configured for the task '${this.name}'`,
+        )
+        process.exit(1)
+      }
+      command = baseCommand + ' ' + command.slice('lazy inherit'.length)
+      command = command.trim()
+    }
+
+    command = command.replaceAll('<rootDir>', this._config.project.root.dir)
+
+    return command
   }
 }
 
@@ -116,7 +148,7 @@ function extractGlobPattern(glob) {
 }
 
 export class Config {
-  /** @private */ rootConfig
+  /** @readonly */ rootConfig
   /** @readonly */ project
 
   /**
@@ -150,13 +182,12 @@ export class Config {
     })
   }
   /**
-   * @param {string} taskDir
+   * @param {import('../project/project-types.js').Workspace} workspace
    * @param {string} taskName
    * @returns {TaskConfig}
    */
-  getTaskConfig(taskDir, taskName) {
-    const config = this.rootConfig.config
-    return new TaskConfig(taskDir, taskName, config?.tasks?.[taskName] ?? {})
+  getTaskConfig(workspace, taskName) {
+    return new TaskConfig(workspace, taskName, this)
   }
 
   /**

--- a/src/manifest/computeManifest.js
+++ b/src/manifest/computeManifest.js
@@ -63,7 +63,7 @@ export async function computeManifest({ tasks, task }) {
   for (const [otherTaskName, depConfig] of task.taskConfig.runsAfterEntries) {
     if (!depConfig.inheritsInput && depConfig.usesOutput === false) continue
     const isTopLevel =
-      tasks.config.getTaskConfig(task.workspace.dir, otherTaskName).execution === 'top-level'
+      tasks.config.getTaskConfig(task.workspace, otherTaskName).execution === 'top-level'
 
     const key = tasks.config.getTaskKey(
       isTopLevel ? tasks.config.project.root.dir : task.workspace.dir,

--- a/src/manifest/getInputFiles.js
+++ b/src/manifest/getInputFiles.js
@@ -49,7 +49,7 @@ function globCacheConfig({ includes, excludes, task, workspaceRoot }) {
  * @returns
  */
 export function getInputFiles(tasks, task, extraFiles) {
-  const taskConfig = tasks.config.getTaskConfig(task.workspace.dir, task.taskName)
+  const taskConfig = tasks.config.getTaskConfig(task.workspace, task.taskName)
 
   const cacheConfig = taskConfig.cache
   if (cacheConfig === 'none') {

--- a/src/runTask.js
+++ b/src/runTask.js
@@ -14,7 +14,7 @@ import { computeManifest } from './manifest/computeManifest.js'
 export async function runTaskIfNeeded(task, tasks) {
   task.logger.restartTimer()
 
-  const taskConfig = tasks.config.getTaskConfig(task.workspace.dir, task.taskName)
+  const taskConfig = tasks.config.getTaskConfig(task.workspace, task.taskName)
 
   const previousManifestPath = taskConfig.getManifestPath()
   const nextManifestPath = taskConfig.getNextManifestPath()


### PR DESCRIPTION
Resolving commands is now moved into `TaskConfig` which handles things like base commands, stripping `lazy inherit`, and now interpolating `<rootDir>`. `runTask` and `lazy inherit` now both use this common command resolution to figure out what to run.

closes #62 