### PR TITLE
Improve lazy inherit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,9 @@ At the time of writing we have one `types.d.ts` file to make it easier to define
 Feel free to submit pull requests! Ask before working on big stuff otherwise you might be disappointed if it gets rejected for some reason.
 
 If there's an issue for the thing you're working on, please let folks know that you're working on it in the issue. Do a quick search in discussions too.
+
+## Testing Locally
+
+If you want to test lazyrepo locally, you can run `pnpm pack-test-version` and then use the resulting tarball to add `lazyrepo` to a local test project.
+
+This test tarball will read the source files from your local git checkout, so you can make changes and test them without having to publish a new version or do any tricky linking.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --list-different .",
     "lint": "eslint -f compact '**/*.{js,ts}'",
+    "pack-test-version": "node scripts/pack-test-version.js",
     "prepare": "husky install"
   },
   "packageManager": "pnpm@8.3.1",

--- a/scripts/pack-test-version.js
+++ b/scripts/pack-test-version.js
@@ -1,0 +1,39 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import pc from 'picocolors'
+import { dedent } from 'ts-dedent'
+import { exec } from './lib/exec.js'
+import { getCurrentVersion } from './lib/getCurrentVersion.js'
+
+const currentVersion = getCurrentVersion()
+// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+const version = '0.0.0-test.' + Date.now()
+exec(`npm version ${version} --no-git-tag-version`)
+const bin = readFileSync('./bin.js')
+const cli = readFileSync('./src/cli.js')
+
+writeFileSync('./bin.js', `#!/usr/bin/env node\n import "file:${process.cwd()}/src/cli.js"`)
+writeFileSync('./src/cli.js', `import "file:${process.cwd()}/src/cli.js"`)
+
+let outPath
+try {
+  outPath = exec(`npm pack`)
+} finally {
+  writeFileSync('./bin.js', bin)
+  writeFileSync('./src/cli.js', cli)
+}
+
+exec(`npm version ${currentVersion} --no-git-tag-version`)
+
+const fullPath = join(process.cwd(), outPath)
+// eslint-disable-next-line no-console
+console.log(dedent`
+  Wrote tarball:
+
+    ${pc.cyan(pc.bold(fullPath))}
+
+  To install:
+
+    ${pc.cyan(pc.bold(`npm install lazyrepo@file:/${fullPath}`))}
+
+`)

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -10,10 +10,11 @@ import { rainbow } from '../rainbow.js'
 
 /**
  * @param {{taskName: string, options: import('../types.js').CLIOption}} args
+ * @param {import('../config/config.js').Config} [_config]
  */
-export async function run({ taskName, options }) {
+export async function run({ taskName, options }, _config) {
   const timer = createTimer()
-  const config = await Config.fromCwd(process.cwd())
+  const config = _config ?? (await Config.fromCwd(process.cwd()))
 
   const filterPaths = options.filter
     ? Array.isArray(options.filter)
@@ -28,7 +29,7 @@ export async function run({ taskName, options }) {
       taskName: taskName,
       filterPaths,
       force: options.force,
-      extraArgs: options['--'],
+      extraArgs: options['--'] ?? [],
     },
   ]
 

--- a/src/execCli.js
+++ b/src/execCli.js
@@ -43,8 +43,10 @@ cli.command('clean', 'delete all local cache data').action(() => {
 
 cli
   .command('inherit', 'run command from configuration file specified by script name')
-  .action(async () => {
-    await inherit()
+  .option('--force', '[boolean] ignore existing cached artifacts', { default: false })
+  .action(async (options) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    await inherit(options)
   })
 
 cli.help()

--- a/src/runTask.js
+++ b/src/runTask.js
@@ -114,6 +114,7 @@ async function runTask(task, tasks) {
       }`,
       FORCE_COLOR: '1',
       npm_lifecycle_event: task.taskName,
+      __LAZY_WORKFLOW__: 'true',
     },
   })
 

--- a/test/extractInheritMatch.test.ts
+++ b/test/extractInheritMatch.test.ts
@@ -1,0 +1,116 @@
+import { extractInheritMatch } from '../src/config/config.js'
+
+describe('extractInheritMatch', () => {
+  it('should extract the inherit match for the plain string', () => {
+    expect(extractInheritMatch('lazy inherit')).toMatchInlineSnapshot(`
+      {
+        "envVars": null,
+        "extraArgs": null,
+      }
+    `)
+    expect(extractInheritMatch('yarn run -T lazy inherit')).toMatchInlineSnapshot(`
+      {
+        "envVars": null,
+        "extraArgs": null,
+      }
+    `)
+    expect(extractInheritMatch('yarn run --top-level lazy inherit')).toMatchInlineSnapshot(`
+      {
+        "envVars": null,
+        "extraArgs": null,
+      }
+    `)
+    expect(extractInheritMatch('yarn run lazy inherit')).toMatchInlineSnapshot(`
+      {
+        "envVars": null,
+        "extraArgs": null,
+      }
+    `)
+  })
+
+  it('should return null if no inherit match is found', () => {
+    expect(extractInheritMatch('test')).toBeNull()
+    expect(extractInheritMatch('lazy test')).toBeNull()
+  })
+
+  it('should handle parsing env vars', () => {
+    expect(extractInheritMatch('FORCE_COLOR=1 lazy inherit')).toMatchInlineSnapshot(`
+      {
+        "envVars": "FORCE_COLOR=1",
+        "extraArgs": null,
+      }
+    `)
+    expect(extractInheritMatch('FORCE_COLOR=1 yarn run lazy inherit')).toMatchInlineSnapshot(`
+      {
+        "envVars": "FORCE_COLOR=1",
+        "extraArgs": null,
+      }
+    `)
+    expect(extractInheritMatch('FORCE_COLOR=1 yarn run -T lazy inherit')).toMatchInlineSnapshot(`
+      {
+        "envVars": "FORCE_COLOR=1",
+        "extraArgs": null,
+      }
+    `)
+    expect(extractInheritMatch('FORCE_COLOR=1 BANANA=yes lazy inherit')).toMatchInlineSnapshot(`
+      {
+        "envVars": "BANANA=yes",
+        "extraArgs": null,
+      }
+    `)
+    expect(extractInheritMatch('FORCE_COLOR=1 BANANA=yes yarn run --top-level lazy inherit'))
+      .toMatchInlineSnapshot(`
+          {
+            "envVars": "BANANA=yes",
+            "extraArgs": null,
+          }
+      `)
+  })
+
+  it('should handle extracting more args', () => {
+    expect(extractInheritMatch('lazy inherit --banana yes')).toMatchInlineSnapshot(`
+      {
+        "envVars": null,
+        "extraArgs": "--banana yes",
+      }
+    `)
+    expect(extractInheritMatch('lazy inherit --banana yes --apple no')).toMatchInlineSnapshot(`
+      {
+        "envVars": null,
+        "extraArgs": "--banana yes --apple no",
+      }
+    `)
+
+    expect(extractInheritMatch('yarn run lazy inherit --banana yes --apple no'))
+      .toMatchInlineSnapshot(`
+      {
+        "envVars": null,
+        "extraArgs": "--banana yes --apple no",
+      }
+    `)
+  })
+
+  it('should handle extracting both env vars and more args', () => {
+    expect(extractInheritMatch('FORCE_COLOR=1 lazy inherit --banana yes')).toMatchInlineSnapshot(`
+      {
+        "envVars": "FORCE_COLOR=1",
+        "extraArgs": "--banana yes",
+      }
+    `)
+    expect(extractInheritMatch('FORCE_COLOR=1 lazy inherit --banana yes --apple no'))
+      .toMatchInlineSnapshot(`
+      {
+        "envVars": "FORCE_COLOR=1",
+        "extraArgs": "--banana yes --apple no",
+      }
+    `)
+
+    expect(extractInheritMatch('FORCE_COLOR=1 yarn run -T lazy inherit --banana yes --apple no'))
+      .toMatchInlineSnapshot(`
+    {
+      "envVars": "FORCE_COLOR=1",
+      "extraArgs": "--banana yes --apple no",
+    }
+  `)
+  })
+})

--- a/test/integration/config.test.ts
+++ b/test/integration/config.test.ts
@@ -166,9 +166,15 @@ test('logs error with exit 1 when config is invalid', async () => {
     async (t) => {
       const { status, output } = await t.exec(['build'], { throwOnError: false })
       expect(status).toBe(1)
-      expect(
-        output.includes(`Failed reading config file at '${t.config.dir}/lazy.config.mjs'`),
-      ).toBe(true)
+      expect(output).toMatchInlineSnapshot(`
+        "lazyrepo 0.0.0-test
+        -------------------
+
+
+        ∙ ERROR ∙ Failed reading config file at '__ROOT_DIR__/lazy.config.mjs'
+        Unrecognized key(s) in object: 'foo'
+        "
+      `)
     },
   )
 })

--- a/test/integration/inherit.test.ts
+++ b/test/integration/inherit.test.ts
@@ -1,0 +1,279 @@
+import { Dir, makeConfigFile, makePackageJson, runIntegrationTest } from './runIntegrationTests.js'
+
+const makeDir = ({
+  baseCommand = 'echo $RANDOM > out.txt',
+  utilsBuildCommand = 'yarn run --top-level lazy inherit',
+  coreBuildCommand = 'lazy inherit',
+} = {}) =>
+  ({
+    'lazy.config.js': makeConfigFile({
+      tasks: {
+        build: {
+          baseCommand,
+          cache: {
+            inputs: {
+              exclude: ['out.txt'],
+            },
+          },
+        },
+      },
+    }),
+    'build.js': `console.log('secret', process.env.SECRET_VAR); console.log('args', process.argv.slice(2))`,
+    packages: {
+      core: {
+        'index.js': 'console.log("hello world")',
+        'package.json': makePackageJson({
+          name: '@test/core',
+          scripts: {
+            build: coreBuildCommand,
+          },
+          dependencies: {
+            '@test/utils': '*',
+          },
+        }),
+      },
+      utils: {
+        'index.js': 'console.log("hello world")',
+        'package.json': makePackageJson({
+          name: '@test/utils',
+          scripts: {
+            build: utilsBuildCommand,
+          },
+        }),
+      },
+    },
+  } satisfies Dir)
+
+test('lazy inherit looks up the command in the config file', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'pnpm',
+      structure: makeDir(),
+      workspaceGlobs: ['packages/*'],
+    },
+    async (t) => {
+      expect(t.exists('packages/core/out.txt')).toBe(false)
+      expect(t.exists('packages/utils/out.txt')).toBe(false)
+      const firstRun = await t.exec(['build'])
+
+      expect(firstRun.status).toBe(0)
+      expect(t.exists('packages/core/out.txt')).toBe(true)
+      expect(firstRun.output).toMatchInlineSnapshot(`
+        "lazyrepo 0.0.0-test
+        -------------------
+        Loaded config file: lazy.config.js
+
+        build::packages/utils Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::packages/utils Finding files matching lazy.config.* took 1.00s
+        build::packages/utils Finding files matching packages/utils/**/* took 1.00s
+        build::packages/utils Hashed 4/4 files in 1.00s
+        build::packages/utils cache miss, no previous manifest found
+        build::packages/utils RUN echo $RANDOM > out.txt in packages/utils
+        build::packages/utils input manifest saved: packages/utils/.lazy/manifests/build
+        build::packages/utils ✔ done in 1.00s
+        build::packages/core Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::packages/core Finding files matching lazy.config.* took 1.00s
+        build::packages/core Finding files matching packages/core/**/* took 1.00s
+        build::packages/core Hashed 4/4 files in 1.00s
+        build::packages/core cache miss, no previous manifest found
+        build::packages/core RUN echo $RANDOM > out.txt in packages/core
+        build::packages/core input manifest saved: packages/core/.lazy/manifests/build
+        build::packages/core ✔ done in 1.00s
+
+             Tasks:  2 successful, 2 total
+            Cached:  0/2 cached
+              Time:  1.00s
+
+        "
+      `)
+
+      const secondRun = await t.exec(['build'])
+
+      expect(secondRun.status).toBe(0)
+      expect(secondRun.output).toMatchInlineSnapshot(`
+        "lazyrepo 0.0.0-test
+        -------------------
+        Loaded config file: lazy.config.js
+
+        build::packages/utils Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::packages/utils Finding files matching lazy.config.* took 1.00s
+        build::packages/utils Finding files matching packages/utils/**/* took 1.00s
+        build::packages/utils Hashed 0/4 files in 1.00s
+        build::packages/utils input manifest saved: packages/utils/.lazy/manifests/build
+        build::packages/utils ✔ cache hit ⚡️ in 1.00s
+        build::packages/core Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::packages/core Finding files matching lazy.config.* took 1.00s
+        build::packages/core Finding files matching packages/core/**/* took 1.00s
+        build::packages/core Hashed 0/4 files in 1.00s
+        build::packages/core input manifest saved: packages/core/.lazy/manifests/build
+        build::packages/core ✔ cache hit ⚡️ in 1.00s
+
+             Tasks:  2 successful, 2 total
+            Cached:  2/2 >>> MAXIMUM LAZY
+              Time:  1.00s
+
+        "
+      `)
+    },
+  )
+})
+test('lazy inherit supports setting env vars', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'pnpm',
+      structure: makeDir({
+        baseCommand: 'node <rootDir>/build.js > out.txt',
+        coreBuildCommand: 'SECRET_VAR=sup lazy inherit',
+        utilsBuildCommand: 'SECRET_VAR=howdy lazy inherit',
+      }),
+      workspaceGlobs: ['packages/*'],
+    },
+    async (t) => {
+      expect(t.exists('packages/core/out.txt')).toBe(false)
+      expect(t.exists('packages/utils/out.txt')).toBe(false)
+      const run = await t.exec(['build'])
+      expect(run.output).toMatchInlineSnapshot(`
+        "lazyrepo 0.0.0-test
+        -------------------
+        Loaded config file: lazy.config.js
+
+        build::packages/utils Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::packages/utils Finding files matching lazy.config.* took 1.00s
+        build::packages/utils Finding files matching packages/utils/**/* took 1.00s
+        build::packages/utils Hashed 4/4 files in 1.00s
+        build::packages/utils cache miss, no previous manifest found
+        build::packages/utils RUN SECRET_VAR=howdy node __ROOT_DIR__/build.js > out.txt in packages/utils
+        build::packages/utils input manifest saved: packages/utils/.lazy/manifests/build
+        build::packages/utils ✔ done in 1.00s
+        build::packages/core Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::packages/core Finding files matching lazy.config.* took 1.00s
+        build::packages/core Finding files matching packages/core/**/* took 1.00s
+        build::packages/core Hashed 4/4 files in 1.00s
+        build::packages/core cache miss, no previous manifest found
+        build::packages/core RUN SECRET_VAR=sup node __ROOT_DIR__/build.js > out.txt in packages/core
+        build::packages/core input manifest saved: packages/core/.lazy/manifests/build
+        build::packages/core ✔ done in 1.00s
+
+             Tasks:  2 successful, 2 total
+            Cached:  0/2 cached
+              Time:  1.00s
+
+        "
+      `)
+      expect(t.read('packages/core/out.txt')).toMatchInlineSnapshot(`
+        "secret sup
+        args []
+        "
+      `)
+      expect(t.read('packages/utils/out.txt')).toMatchInlineSnapshot(`
+        "secret howdy
+        args []
+        "
+      `)
+    },
+  )
+})
+
+test('lazy inherit supports passing args', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'pnpm',
+      structure: makeDir({
+        baseCommand: `node <rootDir>/build.js > out.txt`,
+        coreBuildCommand: 'lazy inherit --foo --bar',
+        utilsBuildCommand: 'lazy inherit --howdy --sup',
+      }),
+      workspaceGlobs: ['packages/*'],
+    },
+    async (t) => {
+      expect(t.exists('packages/core/out.txt')).toBe(false)
+      expect(t.exists('packages/utils/out.txt')).toBe(false)
+      await t.exec(['build'])
+      expect(t.read('packages/core/out.txt')).toMatchInlineSnapshot(`
+        "secret undefined
+        args [ '--foo', '--bar' ]
+        "
+      `)
+      expect(t.read('packages/utils/out.txt')).toMatchInlineSnapshot(`
+        "secret undefined
+        args [ '--howdy', '--sup' ]
+        "
+      `)
+    },
+  )
+})
+
+test('lazy inherit supports passing args and rootDir and env vars', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'pnpm',
+      structure: makeDir({
+        baseCommand: `node <rootDir>/build.js > out.txt`,
+        coreBuildCommand: 'SECRET_VAR=shhh lazy inherit --foo --bar=<rootDir>',
+        utilsBuildCommand: 'SECRET_VAR=hunter2 yarn run -T lazy inherit --howdy --sup',
+      }),
+      workspaceGlobs: ['packages/*'],
+    },
+    async (t) => {
+      expect(t.exists('packages/core/out.txt')).toBe(false)
+      expect(t.exists('packages/utils/out.txt')).toBe(false)
+      await t.exec(['build'])
+      expect(t.read('packages/core/out.txt').includes('--bar=' + t.config.dir)).toBe(true)
+      expect(t.read('packages/utils/out.txt')).toMatchInlineSnapshot(`
+        "secret hunter2
+        args [ '--howdy', '--sup' ]
+        "
+      `)
+    },
+  )
+})
+
+test('calling lazy inherit in the core dir runs the full task graph', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'pnpm',
+      structure: makeDir({
+        baseCommand: `node <rootDir>/build.js > out.txt`,
+        coreBuildCommand: 'SECRET_VAR=shhh lazy inherit --foo --bar=<rootDir>',
+        utilsBuildCommand: 'SECRET_VAR=hunter2 yarn run -T lazy inherit --howdy --sup',
+      }),
+      workspaceGlobs: ['packages/*'],
+    },
+    async (t) => {
+      expect(t.exists('packages/core/out.txt')).toBe(false)
+      expect(t.exists('packages/utils/out.txt')).toBe(false)
+      await t.exec(['build'], { packageDir: 'packages/core' })
+      expect(t.read('packages/core/out.txt').includes('--bar=' + t.config.dir)).toBe(true)
+      expect(t.read('packages/utils/out.txt')).toMatchInlineSnapshot(`
+          "secret hunter2
+          args [ '--howdy', '--sup' ]
+          "
+        `)
+    },
+  )
+})
+
+test('calling lazy inherit in the utils dir runs only the utils build', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'pnpm',
+      structure: makeDir({
+        baseCommand: `node <rootDir>/build.js > out.txt`,
+        coreBuildCommand: 'SECRET_VAR=shhh lazy inherit --foo --bar=<rootDir>',
+        utilsBuildCommand: 'SECRET_VAR=hunter2 yarn run -T lazy inherit --howdy --sup',
+      }),
+      workspaceGlobs: ['packages/*'],
+    },
+    async (t) => {
+      expect(t.exists('packages/core/out.txt')).toBe(false)
+      expect(t.exists('packages/utils/out.txt')).toBe(false)
+      await t.exec(['build'], { packageDir: 'packages/utils' })
+      expect(t.exists('packages/core/out.txt')).toBe(false)
+      expect(t.read('packages/utils/out.txt')).toMatchInlineSnapshot(`
+          "secret hunter2
+          args [ '--howdy', '--sup' ]
+          "
+        `)
+    },
+  )
+})

--- a/test/integration/run.test.ts
+++ b/test/integration/run.test.ts
@@ -1,0 +1,50 @@
+import { Dir, makeConfigFile, runIntegrationTest } from './runIntegrationTests.js'
+
+const makeDir = (): Dir => ({
+  'lazy.config.js': makeConfigFile({
+    tasks: {
+      build: {
+        execution: 'top-level',
+        baseCommand: 'node index.js',
+      },
+    },
+  }),
+  'index.js': 'console.log(JSON.stringify(process.argv.slice(2)))',
+})
+
+test('run passes args after -- to the script', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'pnpm',
+      structure: makeDir(),
+      workspaceGlobs: ['packages/*'],
+    },
+    async (t) => {
+      expect(t.exists('/out.txt')).toBe(false)
+      const firstRun = await t.exec(['build', '--', 'foo', 'bar'])
+
+      expect(firstRun.status).toBe(0)
+      expect(firstRun.output).toMatchInlineSnapshot(`
+        "lazyrepo 0.0.0-test
+        -------------------
+        Loaded config file: lazy.config.js
+
+        build::<rootDir> Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::<rootDir> Finding files matching lazy.config.* took 1.00s
+        build::<rootDir> Finding files matching **/* took 1.00s
+        build::<rootDir> Hashed 5/5 files in 1.00s
+        build::<rootDir> cache miss, no previous manifest found
+        build::<rootDir> RUN node index.js foo bar in 
+        build::<rootDir> ["foo","bar"]
+        build::<rootDir> input manifest saved: .lazy/manifests/build
+        build::<rootDir> ✔ done in 1.00s
+
+             Tasks:  1 successful, 1 total
+            Cached:  0/1 cached
+              Time:  1.00s
+
+        "
+      `)
+    },
+  )
+})


### PR DESCRIPTION
This makes it so that running `lazy inherit` in a workspace dir is the same as calling `lazy run <script> --filter path/to/workspace` from the root. It also adds tests.