### PR TITLE
Allow ignoring workspaces

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,6 +29,7 @@ module.exports = {
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-extra-semi': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
       },
     },
@@ -52,6 +53,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': ['error', { allow: ['arrowFunctions'] }],
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-extra-semi': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
     '@typescript-eslint/restrict-template-expressions': 'off',
   },
 }

--- a/scripts/pack-test-version.js
+++ b/scripts/pack-test-version.js
@@ -11,9 +11,11 @@ const version = '0.0.0-test.' + Date.now()
 exec(`npm version ${version} --no-git-tag-version`)
 const bin = readFileSync('./bin.js')
 const cli = readFileSync('./src/cli.js')
+const types = readFileSync('./index.d.ts')
 
 writeFileSync('./bin.js', `#!/usr/bin/env node\n import "file:${process.cwd()}/src/cli.js"`)
 writeFileSync('./src/cli.js', `import "file:${process.cwd()}/src/cli.js"`)
+writeFileSync('./index.d.ts', `export * from "file:${process.cwd()}/src/config/config-types.d.ts"`)
 
 let outPath
 try {
@@ -21,6 +23,7 @@ try {
 } finally {
   writeFileSync('./bin.js', bin)
   writeFileSync('./src/cli.js', cli)
+  writeFileSync('./index.d.ts', types)
 }
 
 exec(`npm version ${currentVersion} --no-git-tag-version`)

--- a/scripts/pack-test-version.js
+++ b/scripts/pack-test-version.js
@@ -13,15 +13,21 @@ const bin = readFileSync('./bin.js')
 const cli = readFileSync('./src/cli.js')
 const types = readFileSync('./index.d.ts')
 
-writeFileSync('./bin.js', `#!/usr/bin/env node\n import "file:${process.cwd()}/src/cli.js"`)
-writeFileSync('./src/cli.js', `import "file:${process.cwd()}/src/cli.js"`)
-writeFileSync('./index.d.ts', `export * from "file:${process.cwd()}/src/config/config-types.d.ts"`)
+writeFileSync('./bin.js', `#!/usr/bin/env node\n import "${process.cwd()}/src/cli.js"`, {
+  // make executable
+  mode: 0o755,
+})
+writeFileSync('./src/cli.js', `import "${process.cwd()}/src/cli.js"`)
+writeFileSync('./index.d.ts', `export * from "${process.cwd()}/src/config/config-types.js"`)
 
 let outPath
 try {
   outPath = exec(`npm pack`)
 } finally {
-  writeFileSync('./bin.js', bin)
+  writeFileSync('./bin.js', bin, {
+    // make executable
+    mode: 0o755,
+  })
   writeFileSync('./src/cli.js', cli)
   writeFileSync('./index.d.ts', types)
 }

--- a/src/config/config-types.d.ts
+++ b/src/config/config-types.d.ts
@@ -226,4 +226,10 @@ export interface LazyConfig {
    * Custom configuration for any tasks defined in your package.json "scripts" entries.
    */
   tasks?: { [taskName: string]: LazyTask }
+  /**
+   * Ignore workspaces matching the given globs. No tasks will be scheduled to run in these workspaces, ever!
+   *
+   * Warning! This will be true even if another workspace lists one of the ignored workspaces as a dependency.
+   */
+  ignoreWorkspaces?: string[]
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -184,8 +184,9 @@ export class Config {
    * @param {string} cwd
    */
   static async fromCwd(cwd) {
-    const project = Project.fromCwd(cwd)
+    let project = Project.fromCwd(cwd)
     const rootConfig = await resolveConfig(project.root.dir)
+    project = project.withoutIgnoredWorkspaces(rootConfig.config.ignoreWorkspaces ?? [])
 
     if (!rootConfig.filePath) {
       logger.log('No config files found, using default configuration.\n')

--- a/src/config/validateConfig.js
+++ b/src/config/validateConfig.js
@@ -78,6 +78,7 @@ export const lazyConfigSchema = z
       .strict()
       .optional(),
     tasks: z.record(lazyTaskSchema).optional(),
+    ignoreWorkspaces: z.array(z.string()).optional(),
   })
   .strict()
 

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import assert from 'assert'
 import glob from 'fast-glob'
-import path from 'path'
+import micromatch from 'micromatch'
+import path, { isAbsolute, join } from 'path'
 import { findRootWorkspace } from './findRootWorkspace.js'
 import { getPackageManager } from './getPackageManager.js'
 import { loadWorkspace } from './loadWorkspace.js'
@@ -201,6 +203,30 @@ export class Project {
     }
     return workspace
   }
+
+  /**
+   * @param {string[]} ignorePatterns
+   */
+  withoutIgnoredWorkspaces(ignorePatterns) {
+    if (ignorePatterns.length === 0) return this
+    const allWorkspaceDirs = [...this.workspacesByDir.keys()]
+    const ignored = micromatch(
+      allWorkspaceDirs,
+      ignorePatterns.map((pattern) =>
+        isAbsolute(pattern) ? pattern : join(this.root.dir, pattern),
+      ),
+    )
+    const filteredWorkspacesByName = Object.fromEntries(
+      [...this.workspacesByName.entries()].filter(([_, { dir }]) => !ignored.includes(dir)),
+    )
+    return new Project(
+      {
+        workspacesByName: { ...filteredWorkspacesByName, [this.root.name]: this.root },
+        rootWorkspaceName: this.root.name,
+      },
+      this.packageManager,
+    )
+  }
 }
 
 /**
@@ -233,8 +259,8 @@ export function topologicallySortWorkspaces(workspacesByName) {
     if (!workspace) {
       throw new Error(`Could not find package ${packageName}. path: ${path.join(' -> ')}`)
     }
-    for (const childWorkspaceName of workspace.childWorkspaceNames) {
-      visit(childWorkspaceName, [...path, childWorkspaceName])
+    for (const localDependencyName of workspace.localDependencyWorkspaceNames) {
+      visit(localDependencyName, [...path, localDependencyName])
     }
     sorted.push(workspace)
   }

--- a/test/integration/ignoreWorkspaces.test.ts
+++ b/test/integration/ignoreWorkspaces.test.ts
@@ -1,0 +1,121 @@
+import { Dir, makeConfigFile, makePackageJson, runIntegrationTest } from './runIntegrationTests.js'
+
+const makeDir = ({
+  buildCommand = 'echo $RANDOM > out.txt',
+  ignoreWorkspaces = ['packages/utils'],
+} = {}): Dir => ({
+  'lazy.config.js': makeConfigFile({
+    tasks: {
+      build: {
+        cache: {
+          inputs: {
+            exclude: ['out.txt'],
+          },
+        },
+        execution: 'independent',
+      },
+    },
+    ignoreWorkspaces,
+  }),
+  packages: {
+    core: {
+      'index.js': 'console.log("hello world")',
+      'package.json': makePackageJson({
+        name: '@test/core',
+        scripts: {
+          build: buildCommand,
+        },
+        dependencies: {
+          '@test/utils': '*',
+        },
+      }),
+    },
+    utils: {
+      'index.js': 'console.log("hello world")',
+      'package.json': makePackageJson({
+        name: '@test/utils',
+        scripts: {
+          build: buildCommand,
+        },
+      }),
+    },
+  },
+})
+
+test('a workspace can be ignored and things will not run in it', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'pnpm',
+      structure: makeDir(),
+      workspaceGlobs: ['packages/*'],
+    },
+    async (t) => {
+      expect(t.exists('packages/core/out.txt')).toBe(false)
+      expect(t.exists('packages/utils/out.txt')).toBe(false)
+      const firstRun = await t.exec(['build'])
+
+      expect(firstRun.status).toBe(0)
+      expect(t.exists('packages/core/out.txt')).toBe(true)
+      expect(t.exists('packages/utils/out.txt')).toBe(false)
+      expect(firstRun.output).toMatchInlineSnapshot(`
+        "lazyrepo 0.0.0-test
+        -------------------
+        Loaded config file: lazy.config.js
+
+        build::packages/core Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::packages/core Finding files matching lazy.config.* took 1.00s
+        build::packages/core Finding files matching packages/core/**/* took 1.00s
+        build::packages/core Hashed 4/4 files in 1.00s
+        build::packages/core cache miss, no previous manifest found
+        build::packages/core RUN echo $RANDOM > out.txt in packages/core
+        build::packages/core input manifest saved: packages/core/.lazy/manifests/build
+        build::packages/core ✔ done in 1.00s
+
+             Tasks:  1 successful, 1 total
+            Cached:  0/1 cached
+              Time:  1.00s
+
+        "
+      `)
+    },
+  )
+})
+
+test('a workspace can be ignored with a glob pattern', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'pnpm',
+      structure: makeDir({ ignoreWorkspaces: ['packages/c*'] }),
+      workspaceGlobs: ['packages/*'],
+    },
+    async (t) => {
+      expect(t.exists('packages/core/out.txt')).toBe(false)
+      expect(t.exists('packages/utils/out.txt')).toBe(false)
+      const firstRun = await t.exec(['build'])
+
+      expect(firstRun.status).toBe(0)
+      expect(t.exists('packages/core/out.txt')).toBe(false)
+      expect(t.exists('packages/utils/out.txt')).toBe(true)
+      expect(firstRun.output).toMatchInlineSnapshot(`
+        "lazyrepo 0.0.0-test
+        -------------------
+        Loaded config file: lazy.config.js
+
+        build::packages/utils Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::packages/utils Finding files matching lazy.config.* took 1.00s
+        build::packages/utils Finding files matching packages/utils/**/* took 1.00s
+        build::packages/utils Hashed 4/4 files in 1.00s
+        build::packages/utils cache miss, no previous manifest found
+        build::packages/utils RUN echo $RANDOM > out.txt in packages/utils
+        build::packages/utils input manifest saved: packages/utils/.lazy/manifests/build
+        build::packages/utils ✔ done in 1.00s
+
+             Tasks:  1 successful, 1 total
+            Cached:  0/1 cached
+              Time:  1.00s
+
+        "
+      `)
+    },
+  )
+})


### PR DESCRIPTION
This PR adds the ability to filter out particular workspaces, by directory, from the project graph. This prevents tasks from being executed in those directories.