### PR TITLE
Exit after successfully running commands

### DIFF
--- a/src/execCli.js
+++ b/src/execCli.js
@@ -72,6 +72,7 @@ export async function execCli(argv) {
   try {
     cli.parse(argv, { run: false })
     await cli.runMatchedCommand()
+    // the InteractiveLogger runs a setInterval so we need to explicitly call process.exit(0) here to avoid hanging
     process.exit(0)
   } catch (/** @type {any} */ e) {
     // find out if this is a CACError instance

--- a/src/execCli.js
+++ b/src/execCli.js
@@ -72,6 +72,7 @@ export async function execCli(argv) {
   try {
     cli.parse(argv, { run: false })
     await cli.runMatchedCommand()
+    process.exit(0)
   } catch (/** @type {any} */ e) {
     // find out if this is a CACError instance
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access


### PR DESCRIPTION
## Description

Commands like `init` and `clean` did not exit and you had to stop them. This exits the run after successfully running the command.

Would it maybe be better for each command to exit directly, just like the `run` command?

## Change Type

- [x] `patch` — Bug Fix