### PR TITLE
Fix publishing script.

### DIFF
--- a/scripts/publish-new.js
+++ b/scripts/publish-new.js
@@ -117,6 +117,6 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   exec(`npm publish --tag ${prereleaseTag || 'latest'} --access public`)
   if (nextVersion.startsWith('0.0.0')) {
     await waitForPublish(nextVersion)
-    exec(`npm dist-tag add lazyrepo@${nextVersion} latest}`)
+    exec(`npm dist-tag add lazyrepo@${nextVersion} latest`)
   }
 }


### PR DESCRIPTION
## Description

This fixes the publishing script. It was adding an additional `}` to the `latest` tag.

Probably patch, so we publish a new version?

![CleanShot 2023-04-21 at 11 52 21](https://user-images.githubusercontent.com/2523721/233606260-d2bc4dd6-fddc-4291-bcd6-c25dc3b1f1a0.png)

