### PR TITLE
Fix top-level inherit commands

### DIFF
--- a/src/commands/inherit.js
+++ b/src/commands/inherit.js
@@ -16,7 +16,11 @@ export async function inherit(options) {
     process.exit(1)
   }
   const config = await Config.fromCwd(process.cwd())
-  const workspace = config.project.getWorkspaceByDir(process.cwd())
+  const workspace =
+    process.cwd() === config.project.root.dir
+      ? config.project.root
+      : config.project.getWorkspaceByDir(process.cwd())
+
   const task = config.getTaskConfig(workspace, scriptName)
   if (!task.baseCommand) {
     logger.fail(

--- a/test/integration/inherit.test.ts
+++ b/test/integration/inherit.test.ts
@@ -277,3 +277,36 @@ test('calling lazy inherit in the utils dir runs only the utils build', async ()
     },
   )
 })
+
+test('lazy inherit works works with top-level tasks', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'pnpm',
+      structure: {
+        'package.json': makePackageJson({
+          scripts: {
+            build: 'lazy inherit',
+          },
+        }),
+        'lazy.config.js': `
+          module.exports = {
+            tasks: {
+              build: {
+                baseCommand: 'echo "running build"',
+                execution: 'top-level',
+              }
+            }
+          }
+        `,
+        workspace: {
+          'package.json': makePackageJson({ name: 'child' }),
+        },
+      },
+      workspaceGlobs: ['workspace'],
+    },
+    async (t) => {
+      const { output } = await t.exec(['inherit'], { env: { npm_lifecycle_event: 'build' } })
+      expect(output).toContain('running build')
+    },
+  )
+})


### PR DESCRIPTION
## Description

When I added `<rootDir>` interpolation in #66, I changed how `lazy inherit` looks up the command to run, so now it uses `getWorkspaceByDir`. The problem with this is that we exclude the root from the list of workspaces - so if we need to run `lazy inherit` as a top-level task, we can't find the workspace with the command.

This changes that look-up to check if we're in the root dir and explicitly use the root workspace in that case.

## Change Type

<!-- 💡 Indicate the type of change your pull request is. -->
<!-- 🤷‍♀️ If you're not sure, don't select anything -->
<!-- ✂️ Feel free to delete unselected options -->

<!-- To select one, put an x in the box: [x] -->

- [x] `patch` — Bug Fix
- [ ] `minor` — New Feature
- [ ] `major` — Breaking Change

- [ ] `dependencies` — Dependency Update (publishes a `patch` release, for devDependencies use `internal`)

- [ ] `documentation` — Changes to the documentation only (will not publish a new version)
- [ ] `tests` — Changes to any testing-related code only (will not publish a new version)
- [ ] `internal` — Any other changes that don't affect the published package (will not publish a new version)