### PR TITLE
Rename "tasks" config option to "scripts"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ And finally add `.lazy` to your .gitignore
 
 ### Running Tasks
 
-Run tasks defined in `"scripts"` entries using:
+Run scripts defined in `"scripts"` entries using:
 
-    lazy <script-name>
+    lazy run <script-name>
 
 You can pass arguments to the task script after a `--`
 
-    lazy test -- --runInBand
+    lazy run test -- --runInBand
 
 The default behavior is optimized for `"test"` scripts, where the order of execution matters if your packages depend on each other.
 
@@ -55,11 +55,11 @@ graph TD
     A -->|depends on| C[packages/primitives]
 ```
 
-With no config, when you run `lazy test` in the project root:
+With no config, when you run `lazy run test` in the project root:
 
 - The tests for `utils` and `primitives` will begin concurrently. The tests for `core` will only be started if both `utils` and `primitives` finish successfully.
-- If you change a source file in `core` and run `lazy test` again, only `core`'s tests will be executed.
-- If you change a source file in `utils` and run `lazy test` again, both `utils` and `core`'s tests will be executed, in that order.
+- If you change a source file in `core` and run `lazy run test` again, only `core`'s tests will be executed.
+- If you change a source file in `utils` and run `lazy run test` again, both `utils` and `core`'s tests will be executed, in that order.
 
 ### Other commands
 
@@ -89,7 +89,7 @@ With no config, when you run `lazy test` in the project root:
   Then add this in your lazy config file:
 
   ```diff
-   "tasks": {
+   "scripts": {
      "test": {
   +    "baseCommand": "jest --runInBand --noCache --coverage"
      }
@@ -98,11 +98,11 @@ With no config, when you run `lazy test` in the project root:
 
   Now when you run `npm test`, or whatever, in one of your package directories, it will look up the actual command to run from your lazy config file and run that.
 
-- `lazy run <task> [-- <forward-args>]`
+- `lazy run <script> [-- <forward-args>]`
 
-  Runs the given task, forwarding any args passed after the `--`
+  Runs the given script, forwarding any args passed after the `--`
 
-  You may filter the packages that a task should run in using the `--filter` option.
+  You may filter the packages that a script should run in using the `--filter` option, which supports glob patterns.
 
   e.g. to test only packages that end in `-utils`
 
@@ -122,7 +122,7 @@ To create a `.js` config file, in your project root run:
 
 ```ts
 export default {
-  tasks: {
+  scripts: {
     test: {
       cache: {
         // by default we consider all files in the package directory

--- a/src/commands/inherit.js
+++ b/src/commands/inherit.js
@@ -36,6 +36,6 @@ export async function inherit(options) {
     })
     process.exit(result.status ?? 1)
   } else {
-    await run({ taskName: scriptName, options: { ...options, filter: [process.cwd()] } }, config)
+    await run({ scriptName: scriptName, options: { ...options, filter: [process.cwd()] } }, config)
   }
 }

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -9,10 +9,10 @@ import { logger } from '../logger/logger.js'
 import { rainbow } from '../rainbow.js'
 
 /**
- * @param {{taskName: string, options: import('../types.js').CLIOption}} args
+ * @param {{scriptName: string, options: import('../types.js').CLIOption}} args
  * @param {import('../config/config.js').Config} [_config]
  */
-export async function run({ taskName, options }, _config) {
+export async function run({ scriptName, options }, _config) {
   const timer = createTimer()
   const config = _config ?? (await Config.fromCwd(process.cwd()))
 
@@ -26,7 +26,7 @@ export async function run({ taskName, options }, _config) {
   /** @type {import('../types.js').RequestedTask[]} */
   const requestedTasks = [
     {
-      taskName: taskName,
+      scriptName,
       filterPaths,
       force: options.force,
       extraArgs: options['--'] ?? [],
@@ -40,7 +40,7 @@ export async function run({ taskName, options }, _config) {
 
   if (tasks.sortedTaskKeys.length === 0) {
     logger.fail(
-      `No tasks found matching [${requestedTasks.map((t) => t.taskName).join(', ')}] in ${
+      `No tasks found matching [${requestedTasks.map((t) => t.scriptName).join(', ')}] in ${
         config.project.root.dir
       }`,
     )
@@ -49,7 +49,7 @@ export async function run({ taskName, options }, _config) {
   await tasks.runAllTasks()
   if (logger instanceof InteractiveLogger) logger.clearTasks()
 
-  const failedTasks = tasks.allFailedTasks()
+  const failedTasks = tasks.allFailedTaskKeys()
   if (failedTasks.length > 0) {
     logger.logErr(
       pc.bold(pc.red('\nFailed tasks:')),

--- a/src/config/config-types.d.ts
+++ b/src/config/config-types.d.ts
@@ -23,32 +23,32 @@ export type GlobConfig =
 
 export type CacheConfig = {
   /**
-   * Globs of files that this task depends on.
+   * Globs of files that this script depends on.
    *
    * If none are specified, all files in the package will be used.
    */
   inputs?: GlobConfig
   /**
-   * Globs of files that this task produces.
+   * Globs of files that this script produces.
    *
    * If none are specified, none will be tracked.
    */
   outputs?: GlobConfig
   /**
-   * The names of any environment variables that should contribute to the cache key of this task.
-   * Note that it will not control which env vars are passed to the task in any way.
+   * The names of any environment variables that should contribute to the cache key of this script.
+   * Note that it will not control which env vars are passed to the script in any way.
    */
   envInputs?: string[]
   /**
-   * If this task is not independent, this controls whether or not the output created by
-   * upstream packages running this task counts towards the input for the current package.
+   * If this script is not independent, this controls whether or not the output created by
+   * upstream packages running this script counts towards the input for the current package.
    *
    * @default true
    */
   usesOutputFromDependencies?: boolean
   /**
-   * If this task is not independent, this controls whether or not the inputs used by
-   * upstream packages running this task count towards the input for the current package.
+   * If this script is not independent, this controls whether or not the inputs used by
+   * upstream packages running this script count towards the input for the current package.
    *
    * @default true
    */
@@ -57,15 +57,15 @@ export type CacheConfig = {
 
 export type RunsAfter = {
   /**
-   * Whether or not this task uses the files created by the named task.
+   * Whether or not this script uses the files created by the named script.
    * If true, they will be included as cache inputs.
    *
    * @default true
    */
   usesOutput?: boolean
   /**
-   * Whether or not the input files of the named task should contribute to the
-   * cache inputs of this task.
+   * Whether or not the input files of the named script should contribute to the
+   * cache inputs of this script.
    *
    * @default false
    */
@@ -85,10 +85,10 @@ export type RunsAfter = {
   in?: 'all-packages' | 'self-and-dependencies' | 'self-only'
 }
 
-type BaseTask = {
+type BaseScript = {
   /** The other commands that must be completed before this one can run. */
   runsAfter?: {
-    [taskName: string]: RunsAfter
+    [scriptName: string]: RunsAfter
   }
 
   /**
@@ -108,24 +108,24 @@ type BaseTask = {
   parallel?: boolean
 }
 
-export interface TopLevelTask extends BaseTask {
+export interface TopLevelScript extends BaseScript {
   /**
-   * The execution strategy for this task
+   * The execution strategy for this script
    *
    * "dependent" (default)
    *
-   *   The task will run in workspace package directories. It will run in topological order based
+   *   The script will run in workspace package directories. It will run in topological order based
    *   on the dependencies listed in package.json files.
    *
    *   Any tasks that do not depend on each other may be run in parallel, unless specified otherwise.
    *
    * "independent"
    *
-   *   The task will run in workspace package directories, in parallel unless specified otherwise.
+   *   The script will run in workspace package directories, in parallel tasks unless specified otherwise.
    *
    * "top-level"
    *
-   *   The task will run in the root directory of the repo.
+   *   The script will run in the root directory of the repo.
    *   You must specify a command to run.
    *   You may also want to add a `package.json` script with the same name that calls `lazy`.
    *
@@ -133,30 +133,29 @@ export interface TopLevelTask extends BaseTask {
    */
   execution: 'top-level'
   /**
-   * The command to run for this task
+   * The command to run for this script
    */
   baseCommand: string
 }
 
-export interface PackageLevelTask extends BaseTask {
+export interface PackageLevelScript extends BaseScript {
   /**
    * The execution strategy for this script
    *
    * "dependent" (default)
    *
-   *   Lazyrepo will run the script in workspace package directories. These will run in topological order based
-   *   on the dependencies listed in the respective package.json files.
+   *   The script will run in workspace package directories. It will run in topological order based
+   *   on the dependencies listed in package.json files.
    *
    *   Any tasks that do not depend on each other may be run in parallel, unless specified otherwise.
    *
    * "independent"
    *
-   *   Lazyrepo will run the script in workspace package directories. It will not schedule the tasks to complete in any particular order.
-   *   The tasks will run in parallel unless specified otherwise.
+   *   The script will run in workspace package directories, in parallel tasks unless specified otherwise.
    *
    * "top-level"
    *
-   *   Lazyrepo will run the script in the root directory of the repo.
+   *   The script will run in the root directory of the repo.
    *   You must specify a command to run.
    *   You may also want to add a `package.json` script with the same name that calls `lazy`.
    *
@@ -164,23 +163,23 @@ export interface PackageLevelTask extends BaseTask {
    */
   execution?: 'dependent' | 'independent'
   /**
-   * The command to run for this task if the task uses `lazy inherit`
+   * The command to run for this script when invoked via `lazy inherit`
    */
   baseCommand?: string
 
   // API idea
-  // packageOverrides: {
+  // workspaceOverrides: {
   //   [dirGlob: string]: {
   //     command?: string
   //     cache?: 'none' | CacheConfig
   //     runsAfter?: {
-  //       [taskName: string]: RunsAfter
+  //       [scriptName: string]: RunsAfter
   //     }
   //   }
   // }
 }
 
-export type LazyTask = TopLevelTask | PackageLevelTask
+export type LazyScript = TopLevelScript | PackageLevelScript
 
 export interface LazyConfig {
   /**
@@ -223,9 +222,9 @@ export interface LazyConfig {
     envInputs?: string[]
   }
   /**
-   * Custom configuration for any tasks defined in your package.json "scripts" entries.
+   * Custom configuration for any scripts defined in your package.json "scripts" entries.
    */
-  tasks?: { [taskName: string]: LazyTask }
+  scripts?: { [scriptName: string]: LazyScript }
   /**
    * Ignore workspaces matching the given globs. No tasks will be scheduled to run in these workspaces, ever!
    *

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -58,31 +58,32 @@ export class TaskConfig {
     return path.join(dir, slugify(this.name))
   }
 
-  get taskConfig() {
-    return this._config.rootConfig.config.tasks?.[this.name] ?? {}
+  /** @private */
+  get scriptConfig() {
+    return this._config.rootConfig.config.scripts?.[this.name] ?? {}
   }
 
   get execution() {
-    return this.taskConfig.execution ?? 'dependent'
+    return this.scriptConfig.execution ?? 'dependent'
   }
 
   get baseCommand() {
-    return this.taskConfig.baseCommand
+    return this.scriptConfig.baseCommand
   }
 
   /** @type {[string, RunsAfterConfig][]} */
   get runsAfterEntries() {
-    return Object.entries(this.taskConfig.runsAfter ?? {}).map(([name, config]) => {
+    return Object.entries(this.scriptConfig.runsAfter ?? {}).map(([name, config]) => {
       return [name, new RunsAfterConfig(config)]
     })
   }
 
   get parallel() {
-    return this.taskConfig.parallel ?? true
+    return this.scriptConfig.parallel ?? true
   }
 
   get cache() {
-    const cache = this.taskConfig.cache
+    const cache = this.scriptConfig.cache
     if (cache === 'none') {
       return cache
     } else {
@@ -201,20 +202,27 @@ export class Config {
   }
   /**
    * @param {import('../project/project-types.js').Workspace} workspace
-   * @param {string} taskName
+   * @param {string} scriptName
    * @returns {TaskConfig}
    */
-  getTaskConfig(workspace, taskName) {
-    return new TaskConfig(workspace, taskName, this)
+  getTaskConfig(workspace, scriptName) {
+    return new TaskConfig(workspace, scriptName, this)
+  }
+
+  /**
+   * @param {string} scriptName
+   */
+  isTopLevelScript(scriptName) {
+    return this.rootConfig.config.scripts?.[scriptName]?.execution === 'top-level'
   }
 
   /**
    * @param {string} taskDir
-   * @param {string} taskName
+   * @param {string} scriptName
    */
-  getTaskKey(taskDir, taskName) {
+  getTaskKey(taskDir, scriptName) {
     if (!isAbsolute(taskDir)) throw new Error(`taskKey: taskDir must be absolute: ${taskDir}`)
-    return `${taskName}::${relative(this.project.root.dir, taskDir) || '<rootDir>'}`
+    return `${scriptName}::${relative(this.project.root.dir, taskDir) || '<rootDir>'}`
   }
 
   /**

--- a/src/execCli.js
+++ b/src/execCli.js
@@ -12,25 +12,31 @@ import { rainbow } from './rainbow.js'
 const cli = cac('lazy')
 
 cli
-  .command('<task>', 'run task in all packages')
-  .option('--filter <paths>', '[string] run task in packages specified by paths')
-  .option('--force', '[boolean] ignore existing cached artifacts', {
+  .command('<script>', 'run the script in all packages that support it')
+  .option(
+    '--filter="<path-glob>"',
+    '[string] only run the script in packages that match the given path glob',
+  )
+  .option('--force', '[boolean] ignore the cache', {
     default: false,
   })
-  .action(async (taskName, options) => {
+  .action(async (scriptName, options) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    await run({ taskName, options })
+    await run({ scriptName, options })
   })
 
 cli
-  .command('run <task>', 'run task in all packages')
-  .option('--filter <paths>', '[string] run task in packages specified by paths')
-  .option('--force', '[boolean] ignore existing cached artifacts', {
+  .command('run <script>', 'run the script in all packages that support it')
+  .option(
+    '--filter="<path-glob>"',
+    '[string] only run the script in packages that match the given path glob',
+  )
+  .option('--force', '[boolean] ignore the cache', {
     default: false,
   })
-  .action(async (taskName, options) => {
+  .action(async (scriptName, options) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    await run({ taskName, options })
+    await run({ scriptName, options })
   })
 
 cli.command('init', 'create config file').action(() => {
@@ -42,8 +48,11 @@ cli.command('clean', 'delete all local cache data').action(() => {
 })
 
 cli
-  .command('inherit', 'run command from configuration file specified by script name')
-  .option('--force', '[boolean] ignore existing cached artifacts', { default: false })
+  .command(
+    'inherit',
+    '(use in package.json "scripts" only) Runs the command specified in the lazy config file for the script name.',
+  )
+  .option('--force', '[boolean] ignore the cache', { default: false })
   .action(async (options) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     await inherit(options)

--- a/src/manifest/computeManifest.js
+++ b/src/manifest/computeManifest.js
@@ -61,14 +61,14 @@ export async function computeManifest({ tasks, task }) {
 
   const extraFiles = []
 
-  for (const [otherTaskName, depConfig] of task.taskConfig.runsAfterEntries) {
+  for (const [otherScriptName, depConfig] of task.taskConfig.runsAfterEntries) {
     if (!depConfig.inheritsInput && depConfig.usesOutput === false) continue
     const isTopLevel =
-      tasks.config.getTaskConfig(task.workspace, otherTaskName).execution === 'top-level'
+      tasks.config.getTaskConfig(task.workspace, otherScriptName).execution === 'top-level'
 
     const key = tasks.config.getTaskKey(
       isTopLevel ? tasks.config.project.root.dir : task.workspace.dir,
-      otherTaskName,
+      otherScriptName,
     )
     const depTask = tasks.allTasks[key]
     if (isTopLevel && !depTask) throw new Error(`Missing task: ${key}.`)
@@ -94,7 +94,7 @@ export async function computeManifest({ tasks, task }) {
     const upstreamTaskKeys = task.workspace.localDependencyWorkspaceNames
       .map((packageName) => {
         const depPackage = tasks.config.project.getWorkspaceByName(packageName)
-        const key = tasks.config.getTaskKey(depPackage.dir, task.taskName)
+        const key = tasks.config.getTaskKey(depPackage.dir, task.scriptName)
         return key
       })
       .sort()
@@ -112,9 +112,7 @@ export async function computeManifest({ tasks, task }) {
   }
 
   const allEnvVars = uniq(
-    (tasks.config.getBaseCacheConfig().envInputs ?? []).concat(
-      task.taskConfig.cache?.envInputs ?? [],
-    ),
+    tasks.config.getBaseCacheConfig().envInputs.concat(task.taskConfig.cache.envInputs),
   ).sort()
 
   for (const envVar of allEnvVars) {

--- a/src/manifest/getInputFiles.js
+++ b/src/manifest/getInputFiles.js
@@ -49,7 +49,7 @@ function globCacheConfig({ includes, excludes, task, workspaceRoot }) {
  * @returns
  */
 export function getInputFiles(tasks, task, extraFiles) {
-  const taskConfig = tasks.config.getTaskConfig(task.workspace, task.taskName)
+  const taskConfig = tasks.config.getTaskConfig(task.workspace, task.scriptName)
 
   const cacheConfig = taskConfig.cache
   if (cacheConfig === 'none') {

--- a/src/runTask.js
+++ b/src/runTask.js
@@ -14,7 +14,7 @@ import { computeManifest } from './manifest/computeManifest.js'
 export async function runTaskIfNeeded(task, tasks) {
   task.logger.restartTimer()
 
-  const taskConfig = tasks.config.getTaskConfig(task.workspace, task.taskName)
+  const taskConfig = tasks.config.getTaskConfig(task.workspace, task.scriptName)
 
   const previousManifestPath = taskConfig.getManifestPath()
   const nextManifestPath = taskConfig.getNextManifestPath()
@@ -93,7 +93,7 @@ export async function runTaskIfNeeded(task, tasks) {
  * @returns {Promise<{didSucceed: boolean;}>}
  */
 async function runTask(task, tasks) {
-  const taskConfig = tasks.config.getTaskConfig(task.workspace, task.taskName)
+  const taskConfig = tasks.config.getTaskConfig(task.workspace, task.scriptName)
   const command = taskConfig.command
 
   task.logger.log(
@@ -113,7 +113,7 @@ async function runTask(task, tasks) {
         process.env.PATH ?? ''
       }`,
       FORCE_COLOR: '1',
-      npm_lifecycle_event: task.taskName,
+      npm_lifecycle_event: task.scriptName,
       __LAZY_WORKFLOW__: 'true',
     },
   })

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,7 +6,7 @@ export type TaskStatus = 'pending' | 'running' | 'success:eager' | 'success:lazy
 export interface ScheduledTask {
   key: string
   taskConfig: TaskConfig
-  taskName: string
+  scriptName: string
   status: TaskStatus
   force: boolean
   extraArgs: string[]
@@ -23,7 +23,7 @@ export type ManifestChange = {
 }
 
 export type RequestedTask = {
-  taskName: string
+  scriptName: string
   filterPaths: string[]
   extraArgs: string[]
   force: boolean
@@ -64,5 +64,5 @@ export interface TaskLogger extends Logger {
 }
 
 export interface CliLogger extends Logger {
-  task(taskName: string, sortOrder: number): TaskLogger
+  task(scriptName: string, sortOrder: number): TaskLogger
 }

--- a/test/TaskGraph.test.ts
+++ b/test/TaskGraph.test.ts
@@ -53,30 +53,30 @@ function createProject(): Project {
   return makeProject(workspaces)
 }
 
-function makeConfig(project: Project, tasks: LazyConfig['tasks']): Config {
+function makeConfig(project: Project, scripts: LazyConfig['scripts']): Config {
   return new Config({
     project,
     rootConfig: {
       config: {
-        tasks,
+        scripts,
       },
       filePath: null,
     },
   })
 }
 
-function createConfig(tasks: LazyConfig['tasks']): Config {
-  return makeConfig(createProject(), tasks)
+function createConfig(scripts: LazyConfig['scripts']): Config {
+  return makeConfig(createProject(), scripts)
 }
 
 function makeTask(
-  taskName: string,
+  scriptName: string,
   filterPaths: string[] = [],
   extraArgs: string[] = [],
   force = false,
-): { taskName: string; filterPaths: string[]; extraArgs: string[]; force: boolean } {
+): { scriptName: string; filterPaths: string[]; extraArgs: string[]; force: boolean } {
   return {
-    taskName,
+    scriptName,
     filterPaths,
     extraArgs,
     force,
@@ -199,7 +199,7 @@ test('when circular dependencies are detected an error is thrown', () => {
 })
 
 describe('running "pack" on its own in a package with dependencies', () => {
-  const graph = (taskConfig: LazyConfig['tasks']) => {
+  const graph = (taskConfig: LazyConfig['scripts']) => {
     return new TaskGraph({
       config: makeConfig(
         makeProject([
@@ -347,7 +347,7 @@ describe('running "pack" on its own in a package with dependencies', () => {
 })
 
 describe('running "pack" on its own in a package with both dependents and dependencies', () => {
-  const graph = (taskConfig: LazyConfig['tasks']) => {
+  const graph = (taskConfig: LazyConfig['scripts']) => {
     return new TaskGraph({
       config: makeConfig(
         makeProject([

--- a/test/integration/globbing.test.ts
+++ b/test/integration/globbing.test.ts
@@ -11,7 +11,7 @@ test('excludes take precedence', async () => {
             include: ['<rootDir>/scripts/**/*'],
             exclude: ['scripts/tsconfig.tsbuildinfo'],
           },
-          tasks: {
+          scripts: {
             build: {
               cache: {
                 inputs: ['scripts/build.js'],

--- a/test/integration/help.test.ts
+++ b/test/integration/help.test.ts
@@ -36,14 +36,14 @@ test(`help prints with exit 0 when you pass --help`, async () => {
         lazy
 
         Usage:
-          $ lazy <task>
+          $ lazy <script>
 
         Commands:
-          <task>      run task in all packages
-          run <task>  run task in all packages
-          init        create config file
-          clean       delete all local cache data
-          inherit     run command from configuration file specified by script name
+          <script>      run the script in all packages that support it
+          run <script>  run the script in all packages that support it
+          init          create config file
+          clean         delete all local cache data
+          inherit       (use in package.json "scripts" only) Runs the command specified in the lazy config file for the script name.
 
         For more info, run any command with the \`--help\` flag:
           $ lazy --help
@@ -53,9 +53,9 @@ test(`help prints with exit 0 when you pass --help`, async () => {
           $ lazy inherit --help
 
         Options:
-          --filter <paths>  [string] run task in packages specified by paths 
-          --force           [boolean] ignore existing cached artifacts (default: false)
-          -h, --help        Display this message 
+          --filter="<path-glob>"  [string] only run the script in packages that match the given path glob 
+          --force                 [boolean] ignore the cache (default: false)
+          -h, --help              Display this message 
         "
       `)
       expect(status).toBe(0)
@@ -76,19 +76,19 @@ test(`help prints with exit 1 if you pass nothing`, async () => {
       expect(output).toMatchInlineSnapshot(`
         "lazyrepo 0.0.0-test
         -------------------
-        Missing required args for command \`<task>\`
+        Missing required args for command \`<script>\`
 
         lazy
 
         Usage:
-          $ lazy <task>
+          $ lazy <script>
 
         Commands:
-          <task>      run task in all packages
-          run <task>  run task in all packages
-          init        create config file
-          clean       delete all local cache data
-          inherit     run command from configuration file specified by script name
+          <script>      run the script in all packages that support it
+          run <script>  run the script in all packages that support it
+          init          create config file
+          clean         delete all local cache data
+          inherit       (use in package.json "scripts" only) Runs the command specified in the lazy config file for the script name.
 
         For more info, run any command with the \`--help\` flag:
           $ lazy --help
@@ -98,9 +98,9 @@ test(`help prints with exit 1 if you pass nothing`, async () => {
           $ lazy inherit --help
 
         Options:
-          --filter <paths>  [string] run task in packages specified by paths 
-          --force           [boolean] ignore existing cached artifacts (default: false)
-          -h, --help        Display this message 
+          --filter="<path-glob>"  [string] only run the script in packages that match the given path glob 
+          --force                 [boolean] ignore the cache (default: false)
+          -h, --help              Display this message 
         "
       `)
       expect(status).toBe(1)

--- a/test/integration/ignoreWorkspaces.test.ts
+++ b/test/integration/ignoreWorkspaces.test.ts
@@ -5,7 +5,7 @@ const makeDir = ({
   ignoreWorkspaces = ['packages/utils'],
 } = {}): Dir => ({
   'lazy.config.js': makeConfigFile({
-    tasks: {
+    scripts: {
       build: {
         cache: {
           inputs: {

--- a/test/integration/independent.test.ts
+++ b/test/integration/independent.test.ts
@@ -2,7 +2,7 @@ import { Dir, makeConfigFile, makePackageJson, runIntegrationTest } from './runI
 
 const makeDir = ({ buildCommand = 'echo $RANDOM > out.txt' } = {}): Dir => ({
   'lazy.config.js': makeConfigFile({
-    tasks: {
+    scripts: {
       build: {
         cache: {
           inputs: {

--- a/test/integration/inherit.test.ts
+++ b/test/integration/inherit.test.ts
@@ -7,7 +7,7 @@ const makeDir = ({
 } = {}) =>
   ({
     'lazy.config.js': makeConfigFile({
-      tasks: {
+      scripts: {
         build: {
           baseCommand,
           cache: {

--- a/test/integration/run.test.ts
+++ b/test/integration/run.test.ts
@@ -2,7 +2,7 @@ import { Dir, makeConfigFile, runIntegrationTest } from './runIntegrationTests.j
 
 const makeDir = (): Dir => ({
   'lazy.config.js': makeConfigFile({
-    tasks: {
+    scripts: {
       build: {
         execution: 'top-level',
         baseCommand: 'node index.js',

--- a/test/integration/top-level.test.ts
+++ b/test/integration/top-level.test.ts
@@ -2,7 +2,7 @@ import { Dir, makeConfigFile, makePackageJson, runIntegrationTest } from './runI
 
 const makeDir = (): Dir => ({
   'lazy.config.js': makeConfigFile({
-    tasks: {
+    scripts: {
       build: {
         execution: 'top-level',
         cache: {


### PR DESCRIPTION
## Description

This PR renames the `"tasks"` config option to `"scripts"` for clarity.

- A 'script' is a command that can be executed
- A 'task' is an instance of running a script in a particular workspace.

I've updated a lot of variable naming and docs to reflect these differences.

This is a breaking change for typings, but at runtime "tasks" is only deprecated. We still handle it correctly for now, while logging a warning to say that it has been renamed.

## Change Type

<!-- 💡 Indicate the type of change your pull request is. -->
<!-- 🤷‍♀️ If you're not sure, don't select anything -->
<!-- ✂️ Feel free to delete unselected options -->

<!-- To select one, put an x in the box: [x] -->

- [ ] `patch` — Bug Fix
- [ ] `minor` — New Feature
- [x] `major` — Breaking Change

- [ ] `dependencies` — Dependency Update (publishes a `patch` release, for devDependencies use `internal`)

- [ ] `documentation` — Changes to the documentation only (will not publish a new version)
- [ ] `tests` — Changes to any testing-related code only (will not publish a new version)
- [ ] `internal` — Any other changes that don't affect the published package (will not publish a new version)