### PR TITLE
Support workspace overrides

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -41,6 +41,7 @@ module.exports = {
         '@typescript-eslint/no-unsafe-return': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/restrict-plus-operands': 'off',
+        '@typescript-eslint/ban-ts-comment': 'off',
       },
     },
     {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-n": "^15.7.0",
     "husky": "^8.0.0",
+    "immer": "^10.0.1",
     "jest": "^29.5.0",
     "jest-resolve": "^29.5.0",
     "lint-staged": "^13.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       husky:
         specifier: ^8.0.0
         version: 8.0.3
+      immer:
+        specifier: ^10.0.1
+        version: 10.0.1
       jest:
         specifier: ^29.5.0
         version: 29.5.0(@types/node@18.15.11)
@@ -3835,6 +3838,10 @@ packages:
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
+    dev: true
+
+  /immer@10.0.1:
+    resolution: {integrity: sha512-zg++jJLsKKTwXGeSYIw0HgChSYQGtu0UDTnbKx5aGLYgte4CwTmH9eJDYyQ6FheyUtBe+lQW9FrGxya1G+Dtmg==}
     dev: true
 
   /import-cwd@3.0.0:

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,220 @@
+import { join } from 'path'
+import { LazyConfig } from '../index.js'
+import { Config } from '../src/config/config.js'
+import { Project } from '../src/project/Project.js'
+import { Workspace } from '../src/project/project-types.js'
+
+const cwd = process.cwd()
+
+function makeWorkspace(name: string, localDeps: string[], scriptNames: string[]): Workspace {
+  return {
+    dir: join(cwd, `packages/${name}`),
+    name,
+    scripts: Object.fromEntries(scriptNames.map((name) => [name, 'whatever'])),
+    allDependencyNames: localDeps,
+    childWorkspaceGlobs: [],
+    childWorkspaceNames: [],
+    localDependencyWorkspaceNames: localDeps,
+  }
+}
+
+function makeProject(workspaces: Workspace[]): Project {
+  const workspacesByName: Record<string, Workspace> = Object.fromEntries(
+    workspaces
+      .concat([
+        {
+          dir: cwd,
+          name: 'root',
+          scripts: {},
+          allDependencyNames: [],
+          childWorkspaceGlobs: [],
+          childWorkspaceNames: [],
+          localDependencyWorkspaceNames: [],
+        } satisfies Workspace,
+      ])
+      .map((pkg) => [pkg.name, pkg]),
+  )
+  return new Project(
+    {
+      rootWorkspaceName: 'root',
+      workspacesByName,
+    },
+    'npm',
+  )
+}
+
+function createProject(): Project {
+  const workspaces: Workspace[] = [
+    makeWorkspace('core', ['utils'], ['prepack', 'pack', 'core-build']),
+    makeWorkspace('utils', [], ['prepack', 'pack', 'utils-build']),
+  ]
+  return makeProject(workspaces)
+}
+
+function makeConfig(project: Project, scripts: LazyConfig['scripts']): Config {
+  return new Config({
+    project,
+    rootConfig: {
+      config: {
+        scripts,
+      },
+      filePath: null,
+    },
+  })
+}
+
+function createConfig(scripts: LazyConfig['scripts']): Config {
+  return makeConfig(createProject(), scripts)
+}
+
+const getTaskConfig = (config: Config, reltativeDir: string, taskName: string) => {
+  return config.getTaskConfig(
+    config.project.getWorkspaceByDir(join(config.project.root.dir, reltativeDir)),
+    taskName,
+  )
+}
+
+describe('script overrides', () => {
+  it('allow overriding the baseCommand', () => {
+    const config = createConfig({
+      build: {
+        cache: 'none',
+        baseCommand: 'echo root_build',
+        workspaceOverrides: {
+          'packages/core': {
+            baseCommand: 'echo core_build',
+          },
+        },
+      },
+    })
+    expect(getTaskConfig(config, 'packages/utils', 'build').baseCommand).toEqual('echo root_build')
+    expect(getTaskConfig(config, 'packages/core', 'build').baseCommand).toEqual('echo core_build')
+
+    expect(getTaskConfig(config, 'packages/utils', 'build').cache).toEqual('none')
+    expect(getTaskConfig(config, 'packages/core', 'build').cache).toEqual('none')
+  })
+
+  it('uses undefined values to reset to default', () => {
+    const config = createConfig({
+      build: {
+        cache: 'none',
+        workspaceOverrides: {
+          'packages/utils': {
+            cache: undefined,
+          },
+        },
+      },
+    })
+    expect(getTaskConfig(config, 'packages/core', 'build').cache).toEqual('none')
+    expect(getTaskConfig(config, 'packages/utils', 'build').cache).toMatchInlineSnapshot(`
+      {
+        "envInputs": [],
+        "inheritsInputFromDependencies": true,
+        "inputs": {
+          "exclude": [],
+          "include": [
+            "**/*",
+          ],
+        },
+        "outputs": {
+          "exclude": [],
+          "include": [
+            "**/*",
+          ],
+        },
+        "usesOutputFromDependencies": true,
+      }
+    `)
+  })
+
+  it('allows overriding by package name rather than dir', () => {
+    const config = makeConfig(
+      makeProject([
+        { ...makeWorkspace('core', [], ['build']), name: '@foo/core' },
+        { ...makeWorkspace('utils', [], ['build']), name: '@foo/utils' },
+        { ...makeWorkspace('underwear', [], ['build']), name: '@foo/underwear' },
+        { ...makeWorkspace('nothing', [], ['build']), name: '@bar/nothing' },
+      ]),
+      {
+        build: {
+          baseCommand: 'echo root_build',
+          workspaceOverrides: {
+            '@foo/core': {
+              baseCommand: 'echo core_build',
+            },
+            '@foo/u*': {
+              baseCommand: 'echo u_any_build',
+            },
+            '@bar/*': {
+              baseCommand: 'echo bar_build',
+            },
+          },
+        },
+      },
+    )
+
+    expect(getTaskConfig(config, 'packages/core', 'build').baseCommand).toEqual('echo core_build')
+    expect(getTaskConfig(config, 'packages/utils', 'build').baseCommand).toEqual('echo u_any_build')
+    expect(getTaskConfig(config, 'packages/underwear', 'build').baseCommand).toEqual(
+      'echo u_any_build',
+    )
+    expect(getTaskConfig(config, 'packages/nothing', 'build').baseCommand).toEqual('echo bar_build')
+  })
+
+  it('complains if a workspace matches more than one override', () => {
+    const config = makeConfig(
+      makeProject([
+        { ...makeWorkspace('core', [], ['build']), name: '@foo/core' },
+        { ...makeWorkspace('utils', [], ['build']), name: '@foo/utils' },
+        { ...makeWorkspace('underwear', [], ['build']), name: '@foo/underwear' },
+        { ...makeWorkspace('nothing', [], ['build']), name: '@bar/nothing' },
+      ]),
+      {
+        build: {
+          baseCommand: 'echo root_build',
+          workspaceOverrides: {
+            '@foo/core': {
+              baseCommand: 'echo core_build',
+            },
+            'packages/core': {
+              baseCommand: 'echo core_p_build',
+            },
+            '@foo/u*': {
+              baseCommand: 'echo u_any_build',
+            },
+            '@foo/utils': {
+              baseCommand: 'echo u_any_build',
+            },
+            'packages/n*': {
+              baseCommand: 'echo n_any_build',
+            },
+            'packages/nothing': {
+              baseCommand: 'echo nothing_build',
+            },
+          },
+        },
+      },
+    )
+
+    expect(() => {
+      getTaskConfig(config, 'packages/core', 'build').baseCommand
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "Workspace 'packages/core' matched multiple overrides for script "build": ['@foo/core', 'packages/core']
+      Please make sure that the workspace only matches one override."
+    `)
+
+    expect(() => {
+      getTaskConfig(config, 'packages/utils', 'build').baseCommand
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "Workspace 'packages/utils' matched multiple overrides for script "build": ['@foo/u*', '@foo/utils']
+      Please make sure that the workspace only matches one override."
+    `)
+
+    expect(() => {
+      getTaskConfig(config, 'packages/nothing', 'build').baseCommand
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "Workspace 'packages/nothing' matched multiple overrides for script "build": ['packages/n*', 'packages/nothing']
+      Please make sure that the workspace only matches one override."
+    `)
+  })
+})

--- a/test/integration/workspaceOverrides.test.ts
+++ b/test/integration/workspaceOverrides.test.ts
@@ -1,0 +1,170 @@
+import { DependentScript } from '../../index.js'
+import { Dir, makeConfigFile, makePackageJson, runIntegrationTest } from './runIntegrationTests.js'
+
+const makeDir = (workspaceOverrides: DependentScript['workspaceOverrides']) =>
+  ({
+    packages: {
+      core: {
+        'index.js': 'console.log("hello world")',
+        'package.json': makePackageJson({
+          name: '@test/core',
+          scripts: {
+            build: 'echo $RANDOM > .out.core.txt',
+            test: 'echo $RANDOM > .out.core.test.txt',
+          },
+          dependencies: {
+            '@test/utils': '*',
+          },
+        }),
+      },
+      utils: {
+        'index.js': 'console.log("hello world")',
+        'package.json': makePackageJson({
+          name: '@test/utils',
+          scripts: {
+            build: 'echo $RANDOM > .out.utils.txt',
+            test: 'echo $RANDOM > .out.utils.test.txt',
+          },
+        }),
+      },
+    },
+    'lazy.config.js': makeConfigFile({
+      scripts: {
+        build: {
+          cache: 'none',
+          workspaceOverrides,
+        },
+      },
+    }),
+  } satisfies Dir)
+
+test('cache config can be overridden', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'npm',
+      workspaceGlobs: ['packages/*'],
+      structure: makeDir({
+        '@test/utils': {
+          cache: { inputs: ['index.js'] },
+        },
+      }),
+    },
+    async (t) => {
+      const firstRun = await t.exec(['build'])
+
+      expect(firstRun.status).toBe(0)
+      expect(t.exists('packages/core/.out.core.txt')).toBe(true)
+      expect(t.exists('packages/utils/.out.utils.txt')).toBe(true)
+      expect(firstRun.output).toMatchInlineSnapshot(`
+        "lazyrepo 0.0.0-test
+        -------------------
+        Loaded config file: lazy.config.js
+
+        build::packages/utils Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::packages/utils Finding files matching lazy.config.* took 1.00s
+        build::packages/utils Finding files matching packages/utils/index.js took 1.00s
+        build::packages/utils Hashed 3/3 files in 1.00s
+        build::packages/utils cache miss, no previous manifest found
+        build::packages/utils RUN echo $RANDOM > .out.utils.txt in packages/utils
+        build::packages/utils input manifest saved: packages/utils/.lazy/manifests/build
+        build::packages/utils ✔ done in 1.00s
+        build::packages/core cache disabled
+        build::packages/core RUN echo $RANDOM > .out.core.txt in packages/core
+        build::packages/core input manifest saved: packages/core/.lazy/manifests/build
+        build::packages/core ✔ done in 1.00s
+
+             Tasks:  2 successful, 2 total
+            Cached:  0/2 cached
+              Time:  1.00s
+
+        "
+      `)
+
+      const mTimeCore = t.getMtime('packages/core/.out.core.txt')
+      const mTimeUtils = t.getMtime('packages/utils/.out.utils.txt')
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      const secondRun = await t.exec(['build'])
+
+      // core runs again but utils does not because it has a cache config
+
+      expect(secondRun.status).toBe(0)
+      expect(t.getMtime('packages/core/.out.core.txt')).toBeGreaterThan(mTimeCore)
+      expect(t.getMtime('packages/utils/.out.utils.txt')).toBe(mTimeUtils)
+      expect(secondRun.output).toMatchInlineSnapshot(`
+        "lazyrepo 0.0.0-test
+        -------------------
+        Loaded config file: lazy.config.js
+
+        build::packages/utils Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        build::packages/utils Finding files matching lazy.config.* took 1.00s
+        build::packages/utils Finding files matching packages/utils/index.js took 1.00s
+        build::packages/utils Hashed 0/3 files in 1.00s
+        build::packages/utils input manifest saved: packages/utils/.lazy/manifests/build
+        build::packages/utils ✔ cache hit ⚡️ in 1.00s
+        build::packages/core cache disabled
+        build::packages/core RUN echo $RANDOM > .out.core.txt in packages/core
+        build::packages/core input manifest saved: packages/core/.lazy/manifests/build
+        build::packages/core ✔ done in 1.00s
+
+             Tasks:  2 successful, 2 total
+            Cached:  1/2 cached
+              Time:  1.00s
+
+        "
+      `)
+    },
+  )
+})
+
+test('runsAfter can be overridden', async () => {
+  await runIntegrationTest(
+    {
+      packageManager: 'npm',
+      workspaceGlobs: ['packages/*'],
+      structure: makeDir({
+        '@test/utils': {
+          runsAfter: { test: { in: 'self-only' } },
+        },
+      }),
+    },
+    async (t) => {
+      const firstRun = await t.exec(['build'])
+
+      expect(firstRun.status).toBe(0)
+
+      expect(firstRun.output).toMatchInlineSnapshot(`
+        "lazyrepo 0.0.0-test
+        -------------------
+        Loaded config file: lazy.config.js
+
+        test::packages/utils Finding files matching {yarn.lock,pnpm-lock.yaml,package-lock.json} took 1.00s
+        test::packages/utils Finding files matching lazy.config.* took 1.00s
+        test::packages/utils Finding files matching packages/utils/**/* took 1.00s
+        test::packages/utils Hashed 4/4 files in 1.00s
+        test::packages/utils cache miss, no previous manifest found
+        test::packages/utils RUN echo $RANDOM > .out.utils.test.txt in packages/utils
+        test::packages/utils input manifest saved: packages/utils/.lazy/manifests/test
+        test::packages/utils ✔ done in 1.00s
+        build::packages/utils cache disabled
+        build::packages/utils RUN echo $RANDOM > .out.utils.txt in packages/utils
+        build::packages/utils input manifest saved: packages/utils/.lazy/manifests/build
+        build::packages/utils ✔ done in 1.00s
+        build::packages/core cache disabled
+        build::packages/core RUN echo $RANDOM > .out.core.txt in packages/core
+        build::packages/core input manifest saved: packages/core/.lazy/manifests/build
+        build::packages/core ✔ done in 1.00s
+
+             Tasks:  3 successful, 3 total
+            Cached:  0/3 cached
+              Time:  1.00s
+
+        "
+      `)
+      expect(t.exists('packages/core/.out.core.txt')).toBe(true)
+      expect(t.exists('packages/core/.out.core.test.txt')).toBe(false)
+      expect(t.exists('packages/utils/.out.utils.txt')).toBe(true)
+      expect(t.exists('packages/utils/.out.utils.test.txt')).toBe(true)
+    },
+  )
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,1 @@
+// this doesn't do anything right now

--- a/test/validateConfig.test.ts
+++ b/test/validateConfig.test.ts
@@ -1,0 +1,237 @@
+import { produce } from 'immer'
+import { LazyConfig } from '../src/config/resolveConfig.js'
+import { validateConfig } from '../src/config/validateConfig.js'
+
+const validConfig = {
+  baseCacheConfig: {
+    include: ['<rootDir>/package.json', 'yarn.lock', 'pnpm-lock.yaml', 'package-lock.json'],
+    exclude: ['<rootDir>/package.json', 'dist/**/*'],
+    envInputs: ['SOME_ENV_VAR', 'ANOTHER_ENV_VAR'],
+  },
+
+  scripts: {
+    build: {
+      workspaceOverrides: {
+        'packages/workspace-1': {
+          baseCommand: 'yarn build --override',
+          cache: {
+            inputs: ['src/**/*'],
+            outputs: ['dist/**/*'],
+            inheritsInputFromDependencies: true,
+            usesOutputFromDependencies: true,
+          },
+        },
+      },
+      parallel: true,
+      baseCommand: 'yarn build',
+      cache: {
+        inputs: ['src/**/*'],
+        envInputs: ['NODE_ENV'],
+        inheritsInputFromDependencies: true,
+        outputs: ['dist/**/*'],
+        usesOutputFromDependencies: true,
+      },
+    },
+
+    test: {
+      execution: 'independent',
+      baseCommand: 'yarn test',
+      parallel: false,
+      runsAfter: {
+        build: {},
+      },
+      cache: {
+        envInputs: ['NODE_ENV'],
+        inputs: {
+          include: ['src/**/*', 'banana'],
+          exclude: ['dist/**/*'],
+        },
+        outputs: ['dist/**/*'],
+      },
+    },
+
+    publish: {
+      execution: 'top-level',
+      baseCommand: 'yarn publish',
+      cache: {
+        inputs: ['package.json'],
+        outputs: {
+          include: ['dist/**/*'],
+          exclude: ['dist/**/node_modules/**/*'],
+        },
+        envInputs: ['NODE_ENV'],
+      },
+    },
+  },
+
+  ignoreWorkspaces: ['packages/workspace-1', 'packages/workspace-2'],
+} satisfies LazyConfig
+
+const editConfig = (fn: (config: typeof validConfig) => void) => {
+  return produce(validConfig, fn)
+}
+
+describe('validateConfig', () => {
+  it('should validate a valid config', () => {
+    expect(validateConfig(validConfig)).toEqual(validConfig)
+  })
+
+  it('should throw if the config has extra stuff', () => {
+    // add an extra key to the root config
+    expect(() =>
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          draft.extraRootKey = 'extra'
+        }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(`"Unrecognized key(s) in object: 'extraRootKey'"`)
+    // add an extra key to the base cache config
+    expect(() =>
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          draft.baseCacheConfig.extraBaseCacheKey = 'extra'
+        }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unrecognized key(s) in object: 'extraBaseCacheKey' at "baseCacheConfig""`,
+    )
+
+    // add an extra key to the script
+    expect(() =>
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          draft.scripts.build.extraScriptKey = 'extra'
+        }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unrecognized key(s) in object: 'extraScriptKey' at "scripts.build""`,
+    )
+
+    // add an extra key to the workspace override
+    expect(() =>
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          draft.scripts.build.workspaceOverrides['packages/workspace-1'].extraOverrideKey = 'extra'
+        }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unrecognized key(s) in object: 'extraOverrideKey' at "scripts.build.workspaceOverrides.packages/workspace-1""`,
+    )
+  })
+
+  it('should throw an error if the independent cache config has the depenent cache config keys', () => {
+    expect(() =>
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          draft.scripts.test.cache.inheritsInputFromDependencies = true
+        }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unrecognized key(s) in object: 'inheritsInputFromDependencies' at "scripts.test.cache""`,
+    )
+
+    expect(() =>
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          draft.scripts.test.cache.usesOutputFromDependencies = true
+        }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unrecognized key(s) in object: 'usesOutputFromDependencies' at "scripts.test.cache""`,
+    )
+  })
+
+  it('allows the cache config to be the string "none"', () => {
+    expect(
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          draft.scripts.test.cache = 'none'
+        }),
+      ).scripts?.test.cache,
+    ).toEqual('none')
+  })
+
+  it('allows the baseCacheConfig to be undefined', () => {
+    expect(
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          delete draft.baseCacheConfig
+        }),
+      ).baseCacheConfig,
+    ).toBeUndefined()
+  })
+
+  it('allows the baseCacheConfig.include to be undefined', () => {
+    expect(
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          delete draft.baseCacheConfig.include
+        }),
+      ).baseCacheConfig?.include,
+    ).toBeUndefined()
+  })
+
+  it('allows the baseCacheConfig.exclude to be undefined', () => {
+    expect(
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          delete draft.baseCacheConfig.exclude
+        }),
+      ).baseCacheConfig?.exclude,
+    ).toBeUndefined()
+  })
+
+  it('allows the baseCacheConfig.envInputs to be undefined', () => {
+    expect(
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          delete draft.baseCacheConfig.envInputs
+        }),
+      ).baseCacheConfig?.envInputs,
+    ).toBeUndefined()
+  })
+
+  it('allows the scripts to be undefined', () => {
+    expect(
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          delete draft.scripts
+        }),
+      ).scripts,
+    ).toBeUndefined()
+  })
+
+  it('allows the scripts to be an empty object', () => {
+    expect(
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          draft.scripts = {}
+        }),
+      ).scripts,
+    ).toEqual({})
+  })
+
+  it('allows scripts.build to be an empty object', () => {
+    expect(
+      validateConfig(
+        editConfig((draft) => {
+          // @ts-expect-error
+          draft.scripts.build = {}
+        }),
+      ).scripts?.build,
+    ).toEqual({})
+  })
+})


### PR DESCRIPTION
## Description

This adds a `workspaceOverrides` configuration option for non-top-level tasks.

TODO

- [x] Update config
- [x] Add config merging in TaskConfig
- [x] Add tests
- [x] Complain if a workspace matches multiple overrides

## Change Type

- [x] `minor` — New Feature
