### PR TITLE
Make full CI logging opt-in

### DIFF
--- a/src/config/config-types.d.ts
+++ b/src/config/config-types.d.ts
@@ -336,4 +336,8 @@ export interface LazyConfig {
    * Warning! This will be true even if another workspace lists one of the ignored workspaces as a dependency.
    */
   ignoreWorkspaces?: string[]
+  /**
+   * Whether to log manifests directly to the terminal on CI
+   */
+  logManifestsOnCi?: boolean
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -352,4 +352,11 @@ export class Config {
       envInputs: config?.envInputs ?? [],
     }
   }
+
+  /**
+   * @returns {boolean}
+   */
+  get logManifestsOnCi() {
+    return this.rootConfig.config.logManifestsOnCi ?? false
+  }
 }

--- a/src/config/validateConfig.js
+++ b/src/config/validateConfig.js
@@ -134,6 +134,7 @@ export const lazyConfigSchema = z
     scripts: z.record(lazyScriptSchema).optional(),
     tasks: z.record(lazyScriptSchema).optional(),
     ignoreWorkspaces: z.array(z.string()).optional(),
+    logManifestsOnCi: z.boolean().optional(),
   })
   .strict()
 

--- a/src/tasks/runTaskIfNeeded.js
+++ b/src/tasks/runTaskIfNeeded.js
@@ -78,7 +78,7 @@ export async function runTaskIfNeeded(task, tasks) {
 
   if (!didRunTask || didSucceed) {
     task.logger.note('input manifest: ' + relative(cwd, previousManifestPath))
-    if (isCi) {
+    if (isCi && tasks.config.logManifestsOnCi) {
       task.logger.group(
         'input manifest',
         readFileSync(

--- a/test/integration/ci-logging.test.ts
+++ b/test/integration/ci-logging.test.ts
@@ -1,4 +1,4 @@
-import { Dir, makePackageJson, runIntegrationTest } from './runIntegrationTests.js'
+import { Dir, makeConfigFile, makePackageJson, runIntegrationTest } from './runIntegrationTests.js'
 
 const simpleDir = {
   packages: {
@@ -24,6 +24,7 @@ const simpleDir = {
       }),
     },
   },
+  'lazy.config.js': makeConfigFile({ logManifestsOnCi: true }),
 } satisfies Dir
 
 describe('on ci', () => {
@@ -47,14 +48,15 @@ describe('on ci', () => {
         expect(output).toMatchInlineSnapshot(`
           "lazyrepo 0.0.0-test
           -------------------
-          No config files found, using default configuration.
+          Loaded config file: lazy.config.js
 
           build::packages/utils finding files took 1.00s
-          build::packages/utils hashed 3/3 files in 1.00s
+          build::packages/utils hashed 4/4 files in 1.00s
           build::packages/utils cache miss, no previous manifest found
           build::packages/utils RUN echo $RANDOM > .out.txt in packages/utils
           build::packages/utils input manifest: packages/utils/.lazy/build/manifest.tsv
           ::group::build::packages/utils  input manifest
+          file	lazy.config.js	d3592e2a9f8a8206d3870b5d17980068986a638e773c8d103ffda1f426b6a6a9	100.000
           file	package-lock.json	e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855	100.000
           file	packages/utils/index.js	e7fb2f4978d27e4f9e23fe22cea20bb3da1632fabb50362e2963c68700a6f1a5	100.000
           file	packages/utils/package.json	66a4aa54ada27c4596c6e5c7103b46bedef607d952c8985ca520a85c27a16543	100.000
@@ -62,17 +64,63 @@ describe('on ci', () => {
           ::endgroup::
           build::packages/utils ✔ done in 1.00s
           build::packages/core finding files took 1.00s
-          build::packages/core hashed 3/3 files in 1.00s
+          build::packages/core hashed 4/4 files in 1.00s
           build::packages/core cache miss, no previous manifest found
           build::packages/core RUN echo $RANDOM > .out.txt in packages/core
           build::packages/core input manifest: packages/core/.lazy/build/manifest.tsv
           ::group::build::packages/core  input manifest
-          upstream package inputs	build::packages/utils	2699f1c1aec310b2069f1c207e86385d8f65cb7d9c8a03e9b31be18a5ebde35e
+          upstream package inputs	build::packages/utils	bfb72cca7e92aa107893ee16e90022329ba3e1f96cfac17358dcbd196cb233e7
+          file	lazy.config.js	d3592e2a9f8a8206d3870b5d17980068986a638e773c8d103ffda1f426b6a6a9	100.000
           file	package-lock.json	e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855	100.000
           file	packages/core/index.js	e7fb2f4978d27e4f9e23fe22cea20bb3da1632fabb50362e2963c68700a6f1a5	100.000
           file	packages/core/package.json	ea5dc87ceba8dcac6a0c56e525f861a648ee06094ccf5a8fa33b75ac1f3e75c4	100.000
 
           ::endgroup::
+          build::packages/core ✔ done in 1.00s
+
+               Tasks:  2 successful, 2 total
+              Cached:  0/2 cached
+                Time:  1.00s
+
+          "
+        `)
+      },
+    )
+  })
+
+  test('the full manifest is not logged if you did not specify the option', async () => {
+    await runIntegrationTest(
+      {
+        structure: { ...simpleDir, 'lazy.config.js': makeConfigFile({}) },
+        packageManager: 'npm',
+        workspaceGlobs: ['packages/*'],
+      },
+      async (t) => {
+        const { output, status } = await t.exec(['build'], {
+          env: {
+            __test__IS_CI_OVERRIDE: 'true',
+            GITHUB_ACTIONS: 'true',
+            __test__CONSTANT_MTIME: 'true',
+          },
+        })
+
+        expect(status).toBe(0)
+        expect(output).toMatchInlineSnapshot(`
+          "lazyrepo 0.0.0-test
+          -------------------
+          Loaded config file: lazy.config.js
+
+          build::packages/utils finding files took 1.00s
+          build::packages/utils hashed 4/4 files in 1.00s
+          build::packages/utils cache miss, no previous manifest found
+          build::packages/utils RUN echo $RANDOM > .out.txt in packages/utils
+          build::packages/utils input manifest: packages/utils/.lazy/build/manifest.tsv
+          build::packages/utils ✔ done in 1.00s
+          build::packages/core finding files took 1.00s
+          build::packages/core hashed 4/4 files in 1.00s
+          build::packages/core cache miss, no previous manifest found
+          build::packages/core RUN echo $RANDOM > .out.txt in packages/core
+          build::packages/core input manifest: packages/core/.lazy/build/manifest.tsv
           build::packages/core ✔ done in 1.00s
 
                Tasks:  2 successful, 2 total
@@ -118,10 +166,10 @@ describe('on ci', () => {
         expect(secondRun.output).toMatchInlineSnapshot(`
           "lazyrepo 0.0.0-test
           -------------------
-          No config files found, using default configuration.
+          Loaded config file: lazy.config.js
 
           build::packages/utils finding files took 1.00s
-          build::packages/utils hashed 1/2 files in 1.00s
+          build::packages/utils hashed 1/3 files in 1.00s
           build::packages/utils cache miss
           ::group::build::packages/utils  changes since last run
           - removed file packages/utils/index.js
@@ -130,13 +178,14 @@ describe('on ci', () => {
           build::packages/utils RUN echo $RANDOM > .out.txt in packages/utils
           build::packages/utils input manifest: packages/utils/.lazy/build/manifest.tsv
           ::group::build::packages/utils  input manifest
+          file	lazy.config.js	d3592e2a9f8a8206d3870b5d17980068986a638e773c8d103ffda1f426b6a6a9	100.000
           file	package-lock.json	e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855	100.000
           file	packages/utils/package.json	66a4aa54ada27c4596c6e5c7103b46bedef607d952c8985ca520a85c27a16543	100.000
 
           ::endgroup::
           build::packages/utils ✔ done in 1.00s
           build::packages/core finding files took 1.00s
-          build::packages/core hashed 1/4 files in 1.00s
+          build::packages/core hashed 1/5 files in 1.00s
           build::packages/core cache miss
           ::group::build::packages/core  changes since last run
           ± changed upstream package inputs build::packages/utils
@@ -146,7 +195,8 @@ describe('on ci', () => {
           build::packages/core RUN echo $RANDOM > .out.txt in packages/core
           build::packages/core input manifest: packages/core/.lazy/build/manifest.tsv
           ::group::build::packages/core  input manifest
-          upstream package inputs	build::packages/utils	8b4a40e0f67481c7690f423d943417fa32b97951ccff33e6a167396c6be4be74
+          upstream package inputs	build::packages/utils	194d911887b4c64a70785117830794d541da5943c526313d47075223dda3e349
+          file	lazy.config.js	d3592e2a9f8a8206d3870b5d17980068986a638e773c8d103ffda1f426b6a6a9	100.000
           file	package-lock.json	e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855	100.000
           file	packages/core/fun.js	02a83cd560777ec0e33d85bc9dc50fec8de108c55c945443cb608bfa65be9884	100.000
           file	packages/core/index.js	e7fb2f4978d27e4f9e23fe22cea20bb3da1632fabb50362e2963c68700a6f1a5	100.000
@@ -186,10 +236,10 @@ describe('on ci', () => {
         expect(output).toMatchInlineSnapshot(`
           "lazyrepo 0.0.0-test
           -------------------
-          No config files found, using default configuration.
+          Loaded config file: lazy.config.js
 
           build::packages/utils finding files took 1.00s
-          build::packages/utils hashed 3/3 files in 1.00s
+          build::packages/utils hashed 4/4 files in 1.00s
           build::packages/utils cache miss, no previous manifest found
           build::packages/utils RUN echo $RANDOM > .out.txt in packages/utils
           build::packages/utils input manifest: packages/utils/.lazy/build/manifest.tsv
@@ -197,7 +247,7 @@ describe('on ci', () => {
           [ grouped content suppressed on unsupported CI environment ]
           build::packages/utils ✔ done in 1.00s
           build::packages/core finding files took 1.00s
-          build::packages/core hashed 3/3 files in 1.00s
+          build::packages/core hashed 4/4 files in 1.00s
           build::packages/core cache miss, no previous manifest found
           build::packages/core RUN echo $RANDOM > .out.txt in packages/core
           build::packages/core input manifest: packages/core/.lazy/build/manifest.tsv


### PR DESCRIPTION
## Description

Before this PR, lazyrepo logs full manifest files on CI. In practice this hasn't been useful and has actually been quite annoying because the github UI gets super slow when there are thousands of files.

## Change Type

<!-- 💡 Indicate the type of change your pull request is. -->
<!-- 🤷‍♀️ If you're not sure, don't select anything -->
<!-- ✂️ Feel free to delete unselected options -->

<!-- To select one, put an x in the box: [x] -->

- [ ] `patch` — Bug Fix
- [ ] `minor` — New Feature
- [x] `major` — Breaking Change
- [ ] `dependencies` — Dependency Update (publishes a `patch` release, for devDependencies use `internal`)
- [ ] `documentation` — Changes to the documentation only (will not publish a new version)
- [ ] `tests` — Changes to any testing-related code only (will not publish a new version)
- [ ] `internal` — Any other changes that don't affect the published package (will not publish a new version)