### PR TITLE
fix: use platform path delimiter when constructing PATH

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -20,3 +20,5 @@ export const dirname = (...args) => slash(path.dirname(...args))
 export const basename = (...args) => slash(path.basename(...args))
 /** @type {typeof path.normalize} */
 export const normalize = (...args) => slash(path.normalize(...args))
+
+export const delimiter = path.delimiter

--- a/src/tasks/runTask.js
+++ b/src/tasks/runTask.js
@@ -2,7 +2,7 @@ import pc from 'picocolors'
 import stripAnsi from 'strip-ansi'
 import { cwd } from '../cwd.js'
 import { createLazyWriteStream } from '../manifest/createLazyWriteStream.js'
-import { join, relative } from '../path.js'
+import { delimiter, join, relative } from '../path.js'
 import { spawn } from './spawn.js'
 
 /**
@@ -33,9 +33,10 @@ export async function runTask(task, tasks) {
       stdio: [null],
       env: {
         ...process.env,
-        PATH: `./node_modules/.bin:${join(tasks.config.project.root.dir, 'node_modules/.bin')}:${
-          process.env.PATH ?? ''
-        }`,
+        PATH: `./node_modules/.bin${delimiter}${join(
+          tasks.config.project.root.dir,
+          'node_modules/.bin',
+        )}${delimiter}${process.env.PATH ?? ''}`,
         FORCE_COLOR: '1',
         npm_lifecycle_event: task.scriptName,
         __LAZY_WORKFLOW__: 'true',


### PR DESCRIPTION
## Summary

Use the platform-specific path delimiter when constructing the `PATH` environment variable.

## Problem

`runTask` currently constructs `PATH` using a hardcoded `:` separator.

This works on POSIX systems, but Windows uses `;` as the path separator. As a result, local binaries from `node_modules/.bin` may not be resolved correctly.

## Solution

Export `delimiter` from the existing `src/path.js` wrapper and use it when constructing `PATH`.

This preserves the existing behavior on POSIX while fixing Windows compatibility.

## Testing

- Reproduced the issue on native Windows.
- Verified that local binaries resolve correctly after the change.